### PR TITLE
Add maven-central badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![GitHub release](https://img.shields.io/github/release/fppt/jedis-mock.svg)](https://github.com/fppt/jedis-mock/releases/latest)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.fppt/jedis-mock/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.github.fppt/jedis-mock)
 [![Build Status](https://travis-ci.org/fppt/jedis-mock.svg?branch=master)](https://travis-ci.org/fppt/jedis-mock)
 
 # Jedis-Mock


### PR DESCRIPTION
Add maven-central badge in order to simplify the search for the latest version of the library.