### PR TITLE
Fix bug in `exists` implementation

### DIFF
--- a/src/main/java/com/github/fppt/jedismock/operations/RO_exists.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/RO_exists.java
@@ -12,7 +12,7 @@ class RO_exists extends AbstractRedisOperation {
     }
 
     Slice response() {
-        if (base().getValue(params().get(0)) != null) {
+        if (base().exists(params().get(0))) {
             return Response.integer(1);
         }
         return Response.integer(0);

--- a/src/main/java/com/github/fppt/jedismock/storage/ExpiringKeyValueStorage.java
+++ b/src/main/java/com/github/fppt/jedismock/storage/ExpiringKeyValueStorage.java
@@ -121,4 +121,17 @@ public abstract class ExpiringKeyValueStorage {
         }
         return 0L;
     }
+
+    public boolean exists(Slice slice) {
+        if (values().containsRow(slice)) {
+            Long deadline = ttls().get(slice, Slice.reserved());
+            if (deadline != null && deadline != -1 && deadline <= System.currentTimeMillis()) {
+                delete(slice, Slice.reserved());
+                return false;
+            } else {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/src/main/java/com/github/fppt/jedismock/storage/RedisBase.java
+++ b/src/main/java/com/github/fppt/jedismock/storage/RedisBase.java
@@ -108,4 +108,8 @@ public class RedisBase {
 
         return subscriptions;
     }
+
+    public boolean exists(Slice slice) {
+        return keyValueStorage.values().containsRow(slice);
+    }
 }

--- a/src/main/java/com/github/fppt/jedismock/storage/RedisBase.java
+++ b/src/main/java/com/github/fppt/jedismock/storage/RedisBase.java
@@ -110,6 +110,6 @@ public class RedisBase {
     }
 
     public boolean exists(Slice slice) {
-        return keyValueStorage.values().containsRow(slice);
+        return keyValueStorage.exists(slice);
     }
 }

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/SimpleOperationsTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/SimpleOperationsTest.java
@@ -344,4 +344,15 @@ public class SimpleOperationsTest extends ComparisonBase {
     public void whenGettingInfo_EnsureSomeDateIsReturned(Jedis jedis){
         assertNotNull(jedis.info());
     }
+
+    @Theory
+    public void whenCreatingKeys_existsValuesUpdated(Jedis jedis){
+        jedis.set("foo", "bar");
+        assertTrue(jedis.exists("foo"));
+
+        assertFalse(jedis.exists("non-existent"));
+
+        jedis.hset("bar", "baz", "value");
+        assertTrue(jedis.exists("bar"));
+    }
 }


### PR DESCRIPTION
Fixes an issue with `exists` command for HMAPs. 

Previous implementation returned `false` for existing HMAP entries.

Line 355 of `SimpleOperationsTest.java` reproduces the bug.