### PR TITLE
Fix bug in `sadd` implementation

### DIFF
--- a/src/main/java/com/github/fppt/jedismock/operations/OperationFactory.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/OperationFactory.java
@@ -57,6 +57,8 @@ public class OperationFactory {
         TRANSACTIONAL_OPERATIONS.put("keys", RO_keys::new);
         TRANSACTIONAL_OPERATIONS.put("sadd", RO_sadd::new);
         TRANSACTIONAL_OPERATIONS.put("spop", RO_spop::new);
+        TRANSACTIONAL_OPERATIONS.put("srem", RO_srem::new);
+        TRANSACTIONAL_OPERATIONS.put("scard", RO_scard::new);
         TRANSACTIONAL_OPERATIONS.put("hget", RO_hget::new);
         TRANSACTIONAL_OPERATIONS.put("hset", RO_hset::new);
         TRANSACTIONAL_OPERATIONS.put("hdel", RO_hdel::new);

--- a/src/main/java/com/github/fppt/jedismock/operations/RO_exists.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/RO_exists.java
@@ -12,7 +12,7 @@ class RO_exists extends AbstractRedisOperation {
     }
 
     Slice response() {
-        if (base().getValue(params().get(0)) != null) {
+        if (base().exists(params().get(0))) {
             return Response.integer(1);
         }
         return Response.integer(0);

--- a/src/main/java/com/github/fppt/jedismock/operations/RO_sadd.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/RO_sadd.java
@@ -1,5 +1,6 @@
 package com.github.fppt.jedismock.operations;
 
+import com.github.fppt.jedismock.server.Response;
 import com.github.fppt.jedismock.storage.RedisBase;
 import com.github.fppt.jedismock.server.Slice;
 
@@ -7,20 +8,29 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-class RO_sadd extends RO_add<Set<Slice>> {
+import static com.github.fppt.jedismock.Utils.serializeObject;
+
+class RO_sadd extends AbstractRedisOperation {
     RO_sadd(RedisBase base, List<Slice> params) {
         super(base, params);
     }
 
     @Override
-    void addSliceToCollection(Set<Slice> set, Slice slice) {
-        for (int i = 1; i < params().size(); i++) {
-            set.add(params().get(i));
-        }
-    }
+    Slice response() {
+        Slice key = params().get(0);
+        Set<Slice> set = getDataFromBase(key, new HashSet<>());
 
-    @Override
-    Set<Slice> getDefaultResponse() {
-        return new HashSet<>();
+        int count = 0;
+        for (int i = 1; i < params().size(); i++) {
+            if (set.add(params().get(i))){
+                count++;
+            }
+        }
+        try {
+            base().putValue(key, serializeObject(set));
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage());
+        }
+        return Response.integer(count);
     }
 }

--- a/src/main/java/com/github/fppt/jedismock/operations/RO_scard.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/RO_scard.java
@@ -1,0 +1,22 @@
+package com.github.fppt.jedismock.operations;
+
+import com.github.fppt.jedismock.server.Response;
+import com.github.fppt.jedismock.server.Slice;
+import com.github.fppt.jedismock.storage.RedisBase;
+
+import java.util.List;
+import java.util.Set;
+
+class RO_scard extends AbstractRedisOperation {
+
+    RO_scard(RedisBase base, List<Slice> params) {
+        super(base, params);
+    }
+
+    Slice response() {
+        Slice key = params().get(0);
+        Set<Slice> set = getDataFromBase(key, null);
+        if(set == null || set.isEmpty()) return Response.integer(0);
+        return Response.integer(set.size());
+    }
+}

--- a/src/main/java/com/github/fppt/jedismock/operations/RO_srem.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/RO_srem.java
@@ -1,0 +1,36 @@
+package com.github.fppt.jedismock.operations;
+
+import com.github.fppt.jedismock.server.Response;
+import com.github.fppt.jedismock.server.Slice;
+import com.github.fppt.jedismock.storage.RedisBase;
+
+import java.util.List;
+import java.util.Set;
+
+import static com.github.fppt.jedismock.Utils.serializeObject;
+
+class RO_srem extends AbstractRedisOperation {
+
+
+    RO_srem(RedisBase base, List<Slice> params) {
+        super(base, params);
+    }
+
+    Slice response() {
+        Slice key = params().get(0);
+        Set<Slice> set = getDataFromBase(key, null);
+        if(set == null || set.isEmpty()) return Response.integer(0);
+        int count = 0;
+        for (int i = 1; i < params().size(); i++) {
+            if (set.remove(params().get(i))) {
+                count++;
+            }
+        }
+        try {
+            base().putValue(key, serializeObject(set));
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage());
+        }
+        return Response.integer(count);
+    }
+}

--- a/src/main/java/com/github/fppt/jedismock/storage/ExpiringKeyValueStorage.java
+++ b/src/main/java/com/github/fppt/jedismock/storage/ExpiringKeyValueStorage.java
@@ -121,4 +121,17 @@ public abstract class ExpiringKeyValueStorage {
         }
         return 0L;
     }
+
+    public boolean exists(Slice slice) {
+        if (values().containsRow(slice)) {
+            Long deadline = ttls().get(slice, Slice.reserved());
+            if (deadline != null && deadline != -1 && deadline <= System.currentTimeMillis()) {
+                delete(slice, Slice.reserved());
+                return false;
+            } else {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/src/main/java/com/github/fppt/jedismock/storage/RedisBase.java
+++ b/src/main/java/com/github/fppt/jedismock/storage/RedisBase.java
@@ -108,4 +108,8 @@ public class RedisBase {
 
         return subscriptions;
     }
+
+    public boolean exists(Slice slice) {
+        return keyValueStorage.exists(slice);
+    }
 }

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/SimpleOperationsTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/SimpleOperationsTest.java
@@ -210,6 +210,42 @@ public class SimpleOperationsTest extends ComparisonBase {
         String key = "my-set-key-sadd";
         assertEquals(3, jedis.sadd(key, "A", "B", "C", "B").intValue());
         assertEquals(1, jedis.sadd(key, "A", "C", "E", "B").intValue());
+
+    @Theory
+    public void whenAddingToASet_ensureCountIsUpdated(Jedis jedis){
+        String key = "my-counted-set-key";
+        Set<String> mySet = new HashSet<>(Arrays.asList("d", "e", "f"));
+
+        //Add everything from the set
+        mySet.forEach(value -> jedis.sadd(key, value));
+
+        //Get it all back
+        assertEquals(mySet.size(), jedis.scard(key).intValue());
+    }
+
+    @Theory
+    public void whenCalledForNonExistentSet_ensureScardReturnsZero(Jedis jedis){
+        String key = "non-existent";
+        assertEquals(0, jedis.scard(key).intValue());
+    }
+
+    @Theory
+    public void whenRemovingFromASet_EnsureTheSetIsUpdated(Jedis jedis){
+        String key = "my-set-key";
+        Set<String> mySet = new HashSet<>(Arrays.asList("a", "b", "c", "d"));
+
+        //Add everything from the set
+        mySet.forEach(value -> jedis.sadd(key, value));
+
+        // Remove an element
+        mySet.remove("c");
+        mySet.remove("d");
+        mySet.remove("f");
+        int removed = jedis.srem(key, "c", "d", "f").intValue();
+
+        //Get it all back
+        assertEquals(mySet, jedis.smembers(key));
+        assertEquals(2, removed);
     }
 
     @Theory
@@ -351,5 +387,16 @@ public class SimpleOperationsTest extends ComparisonBase {
     @Theory
     public void whenGettingInfo_EnsureSomeDateIsReturned(Jedis jedis){
         assertNotNull(jedis.info());
+    }
+
+    @Theory
+    public void whenCreatingKeys_existsValuesUpdated(Jedis jedis){
+        jedis.set("foo", "bar");
+        assertTrue(jedis.exists("foo"));
+
+        assertFalse(jedis.exists("non-existent"));
+
+        jedis.hset("bar", "baz", "value");
+        assertTrue(jedis.exists("bar"));
     }
 }

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/SimpleOperationsTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/SimpleOperationsTest.java
@@ -206,8 +206,16 @@ public class SimpleOperationsTest extends ComparisonBase {
     }
 
     @Theory
+    public void whenDuplicateValuesAddedToSet_ReturnsAddedValuesCountOnly(Jedis jedis){
+        String key = "my-set-key-sadd";
+        assertEquals(3, jedis.sadd(key, "A", "B", "C", "B").intValue());
+        assertEquals(1, jedis.sadd(key, "A", "C", "E", "B").intValue());
+    }
+
+    @Theory
     public void whenPoppingFromASet_EnsureTheSetIsUpdated(Jedis jedis){
-        String key = "my-set-key";
+
+        String key = "my-set-key-spop";
         Set<String> mySet = new HashSet<>(Arrays.asList("a", "b", "c", "d"));
 
         //Add everything from the set


### PR DESCRIPTION
`sadd` should return the number of added entries, not the size of resulting set.

Thus this is not feasible to inherit `RO_sadd` from `RO_add`. 

The correct `sadd` implementation has more common features with `srem` implemented in PR #28, after the merge we can extract common base class for `sadd` and `srem`.