### PR TITLE
Fix ConcurrentModificationException when deleting hashes with more than one fields

### DIFF
--- a/src/main/java/com/github/fppt/jedismock/storage/ExpiringKeyValueStorage.java
+++ b/src/main/java/com/github/fppt/jedismock/storage/ExpiringKeyValueStorage.java
@@ -22,8 +22,10 @@ public abstract class ExpiringKeyValueStorage {
     }
 
     public void delete(Slice key) {
-        for (Slice key2 : values().row(key).keySet())
-            delete(key, key2);
+        for (Slice key2 : values().row(key).keySet()) {
+            ttls().remove(key, key2);
+        }
+        values().row(key).clear();
     }
 
     public void delete(Slice key1, Slice key2){


### PR DESCRIPTION
In ExpiringKeyValueStore first removes all ttls and than clears the row when `delete(Slice key)` is called to avoid ConcurrentModificationException for rows with more than one column (i.e. hashes with more than one field)