### PR TITLE
Add 'auth' operation. Note that it does not check any password for now.

### DIFF
--- a/src/main/java/com/github/fppt/jedismock/operations/OperationFactory.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/OperationFactory.java
@@ -104,6 +104,8 @@ public class OperationFactory {
                 return Optional.of(new RO_unsubscribe(state, params));
             case "quit":
                 return Optional.of(new RO_quit(state));
+            case "auth":
+                return Optional.of(new RO_auth(state));
             case "exec":
                 return Optional.of(new RO_exec(state));
             default:

--- a/src/main/java/com/github/fppt/jedismock/operations/RO_auth.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/RO_auth.java
@@ -1,0 +1,19 @@
+package com.github.fppt.jedismock.operations;
+
+import com.github.fppt.jedismock.server.Response;
+import com.github.fppt.jedismock.server.Slice;
+import com.github.fppt.jedismock.storage.OperationExecutorState;
+
+public class RO_auth implements RedisOperation {
+    private OperationExecutorState state;
+
+    public RO_auth(OperationExecutorState state) {
+        this.state = state;
+    }
+
+    @Override
+    public Slice execute() {
+        state.owner().sendResponse(Response.clientResponse("auth", Response.OK), "auth");
+        return Response.SKIP;
+    }
+}


### PR DESCRIPTION
For my testing I need to not fail when an [auth](https://redis.io/commands/auth) command is sent.

This change introduces an auth operation, but note that it makes no effort to actually check the given password. I wasn't too sure how to set an expected password value - The ServiceOptions seem like the logical place, but I don't quite understand the design of that right now.

Happy to discuss/refine further if you're open to getting this incorporated.