### PR TITLE
Do not clear TTL when incr/decr a key.

### DIFF
--- a/src/main/java/com/github/fppt/jedismock/operations/RO_incrOrDecrBy.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/RO_incrOrDecrBy.java
@@ -25,7 +25,7 @@ abstract class RO_incrOrDecrBy extends AbstractRedisOperation {
         }
 
         long r = convertToLong(new String(v.data())) + d;
-        base().putValue(key, Slice.create(String.valueOf(r)));
+        base().putValueWithoutClearingTtl(key, Slice.create(String.valueOf(r)));
         return Response.integer(r);
     }
 }

--- a/src/main/java/com/github/fppt/jedismock/storage/ExpiringKeyValueStorage.java
+++ b/src/main/java/com/github/fppt/jedismock/storage/ExpiringKeyValueStorage.java
@@ -101,7 +101,13 @@ public abstract class ExpiringKeyValueStorage {
         Preconditions.checkNotNull(value);
 
         values().put(key1, key2, value);
-        if (ttl != null) {
+        if (ttl == null) {
+            // If a TTL hasn't been provided, we don't want to override the TTL. However, if no TTL is set for this key,
+            // we should still set it to -1L
+            if (getTTL(key1, key2) == null) {
+                setDeadline(key1, key2, -1L);
+            }
+        } else {
             if (ttl != -1) {
                 setTTL(key1, key2, ttl);
             } else {

--- a/src/main/java/com/github/fppt/jedismock/storage/RedisBase.java
+++ b/src/main/java/com/github/fppt/jedismock/storage/RedisBase.java
@@ -53,6 +53,14 @@ public class RedisBase {
         subscribers.clear();
     }
 
+    public void putValueWithoutClearingTtl(Slice key, Slice value) {
+        putValue(key, value, null);
+    }
+
+    public void putValueWithoutClearingTtl(Slice key1, Slice key2, Slice value) {
+        putValue(key1, key2, value, null);
+    }
+
     public void putValue(Slice key, Slice value){
         putValue(key, value, -1L);
     }

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/SimpleOperationsTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/SimpleOperationsTest.java
@@ -770,4 +770,60 @@ public class SimpleOperationsTest extends ComparisonBase {
         assertEquals("myvalue4", results.get(3).getElement());
         assertEquals(20d, results.get(3).getScore(), 0);
     }
+
+    @Theory
+    public void incrDoesNotClearTtl(Jedis jedis) {
+        jedis.flushDB();
+
+        String key = "mykey";
+        jedis.set(key, "0");
+        jedis.expire(key, 100);
+
+        jedis.incr(key);
+        long ttl = jedis.ttl(key);
+
+        assertTrue(ttl > 0);
+    }
+
+    @Theory
+    public void incrByDoesNotClearTtl(Jedis jedis) {
+        jedis.flushDB();
+
+        String key = "mykey";
+        jedis.set(key, "0");
+        jedis.expire(key, 100);
+
+        jedis.incrBy(key, 10);
+        long ttl = jedis.ttl(key);
+
+        assertTrue(ttl > 0);
+    }
+
+    @Theory
+    public void decrDoesNotClearTtl(Jedis jedis) {
+        jedis.flushDB();
+
+        String key = "mykey";
+        jedis.set(key, "0");
+        jedis.expire(key, 100);
+
+        jedis.decr(key);
+        long ttl = jedis.ttl(key);
+
+        assertTrue(ttl > 0);
+    }
+
+    @Theory
+    public void decrByDoesNotClearTtl(Jedis jedis) {
+        jedis.flushDB();
+
+        String key = "mykey";
+        jedis.set(key, "0");
+        jedis.expire(key, 100);
+
+        jedis.decrBy(key, 10);
+        long ttl = jedis.ttl(key);
+
+        assertTrue(ttl > 0);
+    }
 }


### PR DESCRIPTION
According to the Redis spec, TTL should not be cleared when incrementing/decrementing a value.

There are many other operations that should not clear the TTL, this is just addressing incr, incrBy, decr, decrBy.

Fixes #25