### PR TITLE
TTLs should be saved per row, not per cell.

### DIFF
--- a/src/main/java/com/github/fppt/jedismock/storage/ExpiringKeyValueStorage.java
+++ b/src/main/java/com/github/fppt/jedismock/storage/ExpiringKeyValueStorage.java
@@ -4,6 +4,7 @@ import com.github.fppt.jedismock.server.Slice;
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Table;
 
 import java.util.Map;
@@ -15,16 +16,14 @@ import java.util.Map;
 @AutoValue
 public abstract class ExpiringKeyValueStorage {
     public abstract Table<Slice, Slice, Slice> values();
-    public abstract Table<Slice, Slice, Long> ttls();
+    public abstract Map<Slice, Long> ttls();
 
     public static ExpiringKeyValueStorage create(){
-        return new AutoValue_ExpiringKeyValueStorage(HashBasedTable.create(), HashBasedTable.create());
+        return new AutoValue_ExpiringKeyValueStorage(HashBasedTable.create(), Maps.newHashMap());
     }
 
     public void delete(Slice key) {
-        for (Slice key2 : values().row(key).keySet()) {
-            ttls().remove(key, key2);
-        }
+        ttls().remove(key);
         values().row(key).clear();
     }
 
@@ -32,7 +31,10 @@ public abstract class ExpiringKeyValueStorage {
         Preconditions.checkNotNull(key1);
         Preconditions.checkNotNull(key2);
         values().remove(key1, key2);
-        ttls().remove(key1, key2);
+
+        if (!values().containsRow(key1)) {
+            ttls().remove(key1);
+        }
     }
 
     public void clear(){
@@ -52,23 +54,18 @@ public abstract class ExpiringKeyValueStorage {
         Preconditions.checkNotNull(key1);
         Preconditions.checkNotNull(key2);
 
-        Long deadline = ttls().get(key1, key2);
+        Long deadline = ttls().get(key1);
         if (deadline != null && deadline != -1 && deadline <= System.currentTimeMillis()) {
-            delete(key1, key2);
+            delete(key1);
             return null;
         }
         return values().get(key1, key2);
     }
 
-    public Long getTTL(Slice key){
-        return getTTL(key, Slice.reserved());
-    }
+    public Long getTTL(Slice key) {
+        Preconditions.checkNotNull(key);
 
-    public Long getTTL(Slice key1, Slice key2){
-        Preconditions.checkNotNull(key1);
-        Preconditions.checkNotNull(key2);
-
-        Long deadline = ttls().get(key1, key2);
+        Long deadline = ttls().get(key);
         if (deadline == null) {
             return null;
         }
@@ -79,16 +76,12 @@ public abstract class ExpiringKeyValueStorage {
         if (now < deadline) {
             return deadline - now;
         }
-        delete(key1, key1);
+        delete(key);
         return null;
     }
 
     public long setTTL(Slice key, long ttl){
-        return setTTL(key, Slice.reserved(), ttl);
-    }
-
-    public long setTTL(Slice key1, Slice key2, long ttl){
-        return setDeadline(key1, key2, ttl + System.currentTimeMillis());
+        return setDeadline(key, ttl + System.currentTimeMillis());
     }
 
     public void put(Slice key, Slice value, Long ttl){
@@ -103,23 +96,18 @@ public abstract class ExpiringKeyValueStorage {
         values().put(key1, key2, value);
         if (ttl != null) {
             if (ttl != -1) {
-                setTTL(key1, key2, ttl);
+                setTTL(key1, ttl);
             } else {
-                setDeadline(key1, key2, -1L);
+                setDeadline(key1, -1L);
             }
         }
     }
 
     public long setDeadline(Slice key, long deadline) {
-        return setDeadline(key, Slice.reserved(), deadline);
-    }
+        Preconditions.checkNotNull(key);
 
-    public long setDeadline(Slice key1, Slice key2, long deadline) {
-        Preconditions.checkNotNull(key1);
-        Preconditions.checkNotNull(key2);
-
-        if (values().contains(key1, key2)) {
-            ttls().put(key1, key2, deadline);
+        if (values().containsRow(key)) {
+            ttls().put(key, deadline);
             return 1L;
         }
         return 0L;
@@ -127,7 +115,7 @@ public abstract class ExpiringKeyValueStorage {
 
     public boolean exists(Slice slice) {
         if (values().containsRow(slice)) {
-            Long deadline = ttls().get(slice, Slice.reserved());
+            Long deadline = ttls().get(slice);
             if (deadline != null && deadline != -1 && deadline <= System.currentTimeMillis()) {
                 delete(slice, Slice.reserved());
                 return false;

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/SimpleOperationsTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/SimpleOperationsTest.java
@@ -770,4 +770,21 @@ public class SimpleOperationsTest extends ComparisonBase {
         assertEquals("myvalue4", results.get(3).getElement());
         assertEquals(20d, results.get(3).getScore(), 0);
     }
+
+    @Theory
+    public void hashExpires(Jedis jedis) throws InterruptedException {
+        jedis.flushDB();
+
+        String key = "mykey";
+        String subkey = "mysubkey";
+
+        jedis.hsetnx(key, subkey, "a");
+        jedis.expire(key, 1);
+
+        Thread.sleep(2000);
+
+        String result = jedis.hget(key, subkey);
+
+        assertNull(result);
+    }
 }


### PR DESCRIPTION
Looking over the Redis documentation, it seems like TTLs are always saved at "key level" (one TTL per key). There isn't a way to set a TTL on a specific hash entry.

This will probably have some merge conflicts with #65. I can sort that out if you decide you want to merge both.

Fixes #57 