### PR TITLE
sscanIterates test should not count iterations

### DIFF
--- a/src/test/java/com/github/fppt/jedismock/comparisontests/SimpleOperationsTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/SimpleOperationsTest.java
@@ -580,7 +580,7 @@ public class SimpleOperationsTest extends ComparisonBase {
         jedis.flushDB();
 
         String key = "sscankey";
-        jedis.del(key);
+
         String[] values = new String[45];
         for (int i = 0; i < 45; i++) {
             values[i] = (45 - i) + "_value_" + i;
@@ -588,16 +588,17 @@ public class SimpleOperationsTest extends ComparisonBase {
         jedis.sadd(key, values);
         String cursor = null;
 
-        int iterations = 0;
+        Set<String> results = new HashSet<>();
         while (cursor == null || !cursor.equals(ScanParams.SCAN_POINTER_START)) {
             if (cursor == null) {
                 cursor = ScanParams.SCAN_POINTER_START;
             }
             ScanResult<String> result = jedis.sscan(key, cursor);
             cursor = result.getStringCursor();
-            iterations++;
+            results.addAll(result.getResult());
         }
-        assertEquals(5, iterations);
+
+        assertTrue(results.containsAll(Arrays.asList(values)));
     }
 
     @Theory


### PR DESCRIPTION
According to the Redis documentation (https://redis.io/commands/scan), there is no guarantee on the count of items returned by scan, sscan or other related methods. Even specifying a COUNT, the scan methods only use this as a suggestion.

As a result, the sscanIterates test that was counting the number of times the sscan iterates would sometimes fail (if sscan returned more than 10 elements at a time, which is completely valid). Instead of counting the number of iterations, which can never be predicted, I've modified the test to make sure all elements were returned after all iterations complete.

Also removing the `jedis.del(key)` line as the entire DB is erased at the start of the test already.

Fixes #64 