### PR TITLE
Fix hsetnx not returning 0 if field already exists.

### DIFF
--- a/src/main/java/com/github/fppt/jedismock/operations/RO_hsetnx.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/RO_hsetnx.java
@@ -14,7 +14,6 @@ class RO_hsetnx extends RO_hset {
         Slice foundValue = base().getValue(key1, key2);
         if(foundValue == null){
             base().putValue(key1, key2, value, -1L);
-            foundValue = value;
         }
         return foundValue;
     }

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/SimpleOperationsTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/SimpleOperationsTest.java
@@ -494,9 +494,9 @@ public class SimpleOperationsTest {
     @TestTemplate
     public void whenUsingHsetnx_EnsureValueIsOnlyPutIfOtherValueDoesNotExist(Jedis jedis) {
         assertNull(jedis.hget(HASH, FIELD_3));
-        jedis.hsetnx(HASH, FIELD_3, VALUE_1);
+        assertEquals(1, jedis.hsetnx(HASH, FIELD_3, VALUE_1));
         assertEquals(VALUE_1, jedis.hget(HASH, FIELD_3));
-        jedis.hsetnx(HASH, FIELD_3, VALUE_2);
+        assertEquals(0, jedis.hsetnx(HASH, FIELD_3, VALUE_2));
         assertEquals(VALUE_1, jedis.hget(HASH, FIELD_3));
     }
 


### PR DESCRIPTION
According to https://redis.io/commands/hsetnx HSETNX should return 0 if value to be set already exists (and thus was not set), but jedis-mock incorrectly returns 1 in this case.

This patch fixes it and extends the test to verify hsetnx returns a correct value.