### PR TITLE
Add support for client command

### DIFF
--- a/src/main/java/com/github/fppt/jedismock/operations/OperationFactory.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/OperationFactory.java
@@ -117,6 +117,8 @@ public class OperationFactory {
                 return Optional.of(new RO_auth(state));
             case "exec":
                 return Optional.of(new RO_exec(state));
+            case "client":
+                return Optional.of(new RO_client());
             default:
                 return Optional.empty();
         }

--- a/src/main/java/com/github/fppt/jedismock/operations/RO_client.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/RO_client.java
@@ -1,0 +1,12 @@
+package com.github.fppt.jedismock.operations;
+
+import com.github.fppt.jedismock.server.Response;
+import com.github.fppt.jedismock.server.Slice;
+
+public class RO_client implements RedisOperation {
+
+    @Override
+    public Slice execute() {
+        return Response.clientResponse("client", Response.OK);
+    }
+}

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/SimpleOperationsTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/SimpleOperationsTest.java
@@ -506,6 +506,11 @@ public class SimpleOperationsTest {
     }
 
     @TestTemplate
+    public void whenSettingClientName_EnsureOkResponseIsReturned(Jedis jedis) {
+        assertEquals("OK", jedis.clientSetname("P.Myo"));
+    }
+
+    @TestTemplate
     public void whenCreatingKeys_existsValuesUpdated(Jedis jedis) {
         jedis.set("foo", "bar");
         assertTrue(jedis.exists("foo"));


### PR DESCRIPTION
Adding support for the client command so that any clients which set their client name will not fail with an unsupported operation exception.

After creating this PR I noticed #75 addresses this same issue. However, it seems in that PR the client name is sent back in the response, this is not the expected behaviour according to what I saw while debugging a session with a real Redis instance, Redis simply replied `OK`.