### PR TITLE
Add basic support for config set and get

### DIFF
--- a/src/main/java/com/github/fppt/jedismock/operations/OperationFactory.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/OperationFactory.java
@@ -117,6 +117,8 @@ public class OperationFactory {
                 return Optional.of(new RO_auth(state));
             case "exec":
                 return Optional.of(new RO_exec(state));
+            case "config":
+                return Optional.of(new RO_config(state, params));
             default:
                 return Optional.empty();
         }

--- a/src/main/java/com/github/fppt/jedismock/operations/RO_config.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/RO_config.java
@@ -1,0 +1,41 @@
+package com.github.fppt.jedismock.operations;
+
+import com.github.fppt.jedismock.server.Response;
+import com.github.fppt.jedismock.server.Slice;
+import com.github.fppt.jedismock.storage.OperationExecutorState;
+import com.google.common.collect.Lists;
+import java.util.List;
+
+public class RO_config implements RedisOperation {
+
+    private final OperationExecutorState state;
+    private final List<Slice> params;
+
+    RO_config(OperationExecutorState state, List<Slice> params) {
+        this.state = state;
+        this.params = params;
+    }
+
+    @Override
+    public Slice execute() {
+        int parameterCount = params.size();
+        if (parameterCount == 2) {
+            return doGet();
+        } else if (parameterCount == 3) {
+            return doSet();
+        }
+        throw new IllegalArgumentException("Invalid number of arguments for config command, got " + parameterCount + " expected 2 or 3.");
+    }
+
+    private Slice doGet() {
+        Slice configKey = params.get(1);
+        return Response.array(Lists.newArrayList(Response.bulkString(configKey), Response.bulkString(state.base().getConfig(configKey))));
+    }
+
+    private Slice doSet() {
+        Slice configKey = params.get(1);
+        Slice configValue = params.get(2);
+        state.base().setConfig(configKey, configValue);
+        return Response.OK;
+    }
+}

--- a/src/main/java/com/github/fppt/jedismock/storage/RedisBase.java
+++ b/src/main/java/com/github/fppt/jedismock/storage/RedisBase.java
@@ -17,6 +17,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class RedisBase {
     private final ExpiringKeyValueStorage keyValueStorage = ExpiringKeyValueStorage.create();
     private final Map<Slice, Set<RedisClient>> subscribers = new ConcurrentHashMap<>();
+    private final Map<Slice, Slice> configs = new ConcurrentHashMap<>();
 
     public RedisBase() {}
 
@@ -119,5 +120,16 @@ public class RedisBase {
 
     public boolean exists(Slice slice) {
         return keyValueStorage.exists(slice);
+    }
+
+    public Slice getConfig(Slice config) {
+        if (configs.containsKey(config)) {
+            return configs.get(config);
+        }
+        return Slice.create(new byte[] {});
+    }
+
+    public void setConfig(Slice config, Slice value) {
+        configs.put(config, value);
     }
 }

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/SimpleOperationsTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/SimpleOperationsTest.java
@@ -506,6 +506,25 @@ public class SimpleOperationsTest {
     }
 
     @TestTemplate
+    public void whenGetNonExistentConfig_EnsureEmptyResultIsReturned(Jedis jedis) {
+        List<String> results = jedis.configGet("requirepass");
+        assertEquals(2, results.size());
+        assertEquals("requirepass", results.get(0));
+        assertEquals("", results.get(1));
+    }
+
+    @TestTemplate
+    public void whenSetConfig_EnsureOkResponseIsReturned(Jedis jedis) {
+        String configKey = "notify-keyspace-events";
+
+        assertEquals("OK", jedis.configSet(configKey, "AKE"));
+
+        List<String> result = jedis.configGet(configKey);
+        assertEquals(configKey, result.get(0));
+        assertEquals("AKE", result.get(1));
+    }
+
+    @TestTemplate
     public void whenCreatingKeys_existsValuesUpdated(Jedis jedis) {
         jedis.set("foo", "bar");
         assertTrue(jedis.exists("foo"));


### PR DESCRIPTION
Adding support for `CONFIG GET x` and `CONFIG SET x y` where x is the full configuration parameter name.
This implementation lacks support for the glob-style patterns which Redis allows.