### PR TITLE
Make HSET variadic

### DIFF
--- a/src/main/java/com/github/fppt/jedismock/operations/RO_hmset.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/RO_hmset.java
@@ -6,20 +6,14 @@ import com.github.fppt.jedismock.storage.RedisBase;
 
 import java.util.List;
 
-public class RO_hmset extends AbstractRedisOperation {
+public class RO_hmset extends RO_hset {
     public RO_hmset(RedisBase base, List<Slice> params) {
         super(base, params);
     }
 
     @Override
     Slice response() {
-        Slice hash = params().get(0);
-
-        for(int i = 1; i < params().size(); i = i + 2){
-            Slice field = params().get(i);
-            Slice value = params().get(i+1);
-            base().putValue(hash, field, value, -1L);
-        }
+        super.response();
 
         return Response.OK;
     }

--- a/src/main/java/com/github/fppt/jedismock/operations/RO_hset.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/RO_hset.java
@@ -17,16 +17,21 @@ class RO_hset extends AbstractRedisOperation {
         return foundValue;
     }
 
+    @Override
     Slice response() {
-        Slice key1 = params().get(0);
-        Slice key2 = params().get(1);
-        Slice value = params().get(2);
-        Slice oldValue = hsetValue(key1, key2, value);
+        Slice hash = params().get(0);
+        int count = 0;
 
-        if(oldValue == null){
-            return Response.integer(1);
-        } else {
-            return Response.integer(0);
+        for(int i = 1; i < params().size(); i = i + 2){
+            Slice field = params().get(i);
+            Slice value = params().get(i+1);
+            Slice oldValue = hsetValue(hash, field, value);
+
+            if(oldValue == null) {
+                count++;
+            }
         }
+
+        return Response.integer(count);
     }
 }

--- a/src/test/java/com/github/fppt/jedismock/TestRedisOperationExecutor.java
+++ b/src/test/java/com/github/fppt/jedismock/TestRedisOperationExecutor.java
@@ -286,6 +286,15 @@ public class TestRedisOperationExecutor {
     }
 
     @Test
+    public void testHset() {
+        assertCommandEquals(2, array("hset", "h", "a", "v1", "b", "v2"));
+        assertCommandEquals(1, array("hset", "h", "a", "v1", "c", "v3"));
+        assertCommandArrayEquals(array("v1"), array("hmget", "h", "a"));
+        assertCommandArrayEquals(array("v2"), array("hmget", "h", "b"));
+        assertCommandArrayEquals(array("v3"), array("hmget", "h", "c"));
+    }
+
+    @Test
     public void testStrlen() throws ParseErrorException {
         assertCommandEquals(0, array("strlen", "a"));
         assertCommandOK(array("SET", "a", "abd"));


### PR DESCRIPTION
As seen [https://redis.io/commands/hset](here), since redis version 4.0.0 HSET is variadic and it is encouraged in the [https://redis.io/commands/hmset](HMSET Documentation) to use HSET. This PR adds that functionality.

As seen in the documentations above, the only difference between HSET and HMSET is that HMSET returns "OK" after the operation is completed while HSET returns the number of added fields.
