### PR TITLE
Stop processing client connections when the client is disconnected

### DIFF
--- a/src/main/java/com/github/fppt/jedismock/RedisServer.java
+++ b/src/main/java/com/github/fppt/jedismock/RedisServer.java
@@ -1,14 +1,18 @@
 package com.github.fppt.jedismock;
 
+import com.github.fppt.jedismock.server.RedisClient;
 import com.github.fppt.jedismock.server.RedisService;
 import com.github.fppt.jedismock.server.ServiceOptions;
 import com.github.fppt.jedismock.storage.RedisBase;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 
 import java.io.IOException;
 import java.net.ServerSocket;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * Created by Xiaolu on 2015/4/18.
@@ -20,6 +24,7 @@ public class RedisServer {
     private ServerSocket server = null;
     private Thread service = null;
     private final Map<Integer, RedisBase> redisBases = new HashMap<>();
+    private final Collection<RedisClient> connectedClients = new CopyOnWriteArrayList<>();
 
     public RedisServer() throws IOException {
         this(0);
@@ -47,7 +52,7 @@ public class RedisServer {
         Preconditions.checkState(service == null);
 
         server = new ServerSocket(bindPort);
-        service = new Thread(new RedisService(server, redisBases, options));
+        service = new Thread(new RedisService(server, redisBases, connectedClients, options));
         service.start();
     }
 
@@ -85,5 +90,10 @@ public class RedisServer {
     public int getBindPort() {
         Preconditions.checkNotNull(server);
         return server.getLocalPort();
+    }
+
+    @VisibleForTesting
+    Collection<RedisClient> getConnectedClients() {
+        return connectedClients;
     }
 }

--- a/src/main/java/com/github/fppt/jedismock/commands/RedisCommandParser.java
+++ b/src/main/java/com/github/fppt/jedismock/commands/RedisCommandParser.java
@@ -1,5 +1,6 @@
 package com.github.fppt.jedismock.commands;
 
+import com.github.fppt.jedismock.exception.EOFException;
 import com.github.fppt.jedismock.server.SliceParser;
 import com.github.fppt.jedismock.exception.ParseErrorException;
 import com.google.common.annotations.VisibleForTesting;
@@ -17,10 +18,15 @@ public class RedisCommandParser {
     public static RedisCommand parse(String stringInput) throws ParseErrorException {
         Preconditions.checkNotNull(stringInput);
 
-        return parse(new ByteArrayInputStream(stringInput.getBytes()));
+        try {
+            return parse(new ByteArrayInputStream(stringInput.getBytes()));
+        } catch (EOFException e){
+            // This is a stream over an in-memory byte array, so we shouldn't get this error
+            throw new ParseErrorException();
+        }
     }
 
-    public static RedisCommand parse(InputStream messageInput) throws ParseErrorException {
+    public static RedisCommand parse(InputStream messageInput) throws ParseErrorException, EOFException {
         Preconditions.checkNotNull(messageInput);
 
         long count = SliceParser.consumeCount(messageInput);

--- a/src/main/java/com/github/fppt/jedismock/server/RedisService.java
+++ b/src/main/java/com/github/fppt/jedismock/server/RedisService.java
@@ -6,6 +6,7 @@ import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.util.Collection;
 import java.util.Map;
 
 /**
@@ -15,15 +16,18 @@ public class RedisService implements Runnable {
 
     private final ServerSocket server;
     private final Map<Integer, RedisBase> redisBases;
+    private final Collection<RedisClient> connectedClients;
     private final ServiceOptions options;
 
-    public RedisService(ServerSocket server, Map<Integer, RedisBase> redisBases, ServiceOptions options) {
+    public RedisService(ServerSocket server, Map<Integer, RedisBase> redisBases, Collection<RedisClient> connectedClients, ServiceOptions options) {
         Preconditions.checkNotNull(server);
         Preconditions.checkNotNull(redisBases);
+        Preconditions.checkNotNull(connectedClients);
         Preconditions.checkNotNull(options);
 
         this.server = server;
         this.redisBases = redisBases;
+        this.connectedClients = connectedClients;
         this.options = options;
     }
 
@@ -31,7 +35,7 @@ public class RedisService implements Runnable {
         while (!server.isClosed()) {
             try {
                 Socket socket = server.accept();
-                Thread t = new Thread(new RedisClient(redisBases, socket, options));
+                Thread t = new Thread(new RedisClient(redisBases, connectedClients, socket, options));
                 t.start();
             } catch (IOException e) {
                 // Do noting

--- a/src/main/java/com/github/fppt/jedismock/server/SliceParser.java
+++ b/src/main/java/com/github/fppt/jedismock/server/SliceParser.java
@@ -73,20 +73,21 @@ public class SliceParser {
     }
 
     @VisibleForTesting
-    public static long consumeCount(InputStream messageInput) throws ParseErrorException {
-        try {
-            expectByte(messageInput, (byte) '*');
-            long count = consumeLong(messageInput);
-            expectByte(messageInput, (byte) '\n');
-            return count;
-        } catch (EOFException e) {
-            throw new ParseErrorException();
-        }
+    public static long consumeCount(InputStream messageInput) throws ParseErrorException, EOFException {
+        expectByte(messageInput, (byte) '*');
+        long count = consumeLong(messageInput);
+        expectByte(messageInput, (byte) '\n');
+        return count;
     }
 
     public static long consumeCount(byte[] message) throws ParseErrorException {
-        InputStream stream = new ByteArrayInputStream(message);
-        return consumeCount(stream);
+        try {
+            InputStream stream = new ByteArrayInputStream(message);
+            return consumeCount(stream);
+        } catch (EOFException e){
+            // This is a stream over an in-memory byte array, so we shouldn't get this error
+            throw new ParseErrorException();
+        }
     }
 
     public static int consumeInteger(byte[] message) throws ParseErrorException {
@@ -108,22 +109,23 @@ public class SliceParser {
         return '0' <= c && c <= '9';
     }
 
-    public static Slice consumeParameter(InputStream messageInput) throws ParseErrorException {
-        try {
-            expectByte(messageInput, (byte) '$');
-            long len = consumeLong(messageInput);
-            expectByte(messageInput, (byte) '\n');
-            Slice para = consumeSlice(messageInput, len);
-            expectByte(messageInput, (byte) '\r');
-            expectByte(messageInput, (byte) '\n');
-            return para;
-        } catch (EOFException e) {
-            throw new ParseErrorException();
-        }
+    public static Slice consumeParameter(InputStream messageInput) throws ParseErrorException, EOFException {
+        expectByte(messageInput, (byte) '$');
+        long len = consumeLong(messageInput);
+        expectByte(messageInput, (byte) '\n');
+        Slice para = consumeSlice(messageInput, len);
+        expectByte(messageInput, (byte) '\r');
+        expectByte(messageInput, (byte) '\n');
+        return para;
     }
 
     public static Slice consumeParameter(byte[] message) throws ParseErrorException {
-        InputStream stream = new ByteArrayInputStream(message);
-        return consumeParameter(stream);
+        try {
+            InputStream stream = new ByteArrayInputStream(message);
+            return consumeParameter(stream);
+        } catch (EOFException e){
+            // This is a stream over an in-memory byte array, so we shouldn't get this error
+            throw new ParseErrorException();
+        }
     }
 }

--- a/src/test/java/com/github/fppt/jedismock/TestCommandParser.java
+++ b/src/test/java/com/github/fppt/jedismock/TestCommandParser.java
@@ -44,7 +44,7 @@ public class TestCommandParser {
     }
 
     @Test
-    public void testConsumeCount1() throws ParseErrorException {
+    public void testConsumeCount1() throws ParseErrorException, EOFException {
         InputStream stream = new ByteArrayInputStream("*12\r\n".getBytes());
         assertEquals(SliceParser.consumeCount(stream), 12L);
     }
@@ -55,14 +55,14 @@ public class TestCommandParser {
         try {
             SliceParser.consumeCount(stream);
             fail();
-        } catch (ParseErrorException e) {
+        } catch (EOFException e) {
             // OK
         }
     }
 
 
     @Test
-    public void testConsumeParameter() throws ParseErrorException {
+    public void testConsumeParameter() throws ParseErrorException, EOFException {
         InputStream stream = new ByteArrayInputStream("$5\r\nabcde\r\n".getBytes());
         assertEquals(SliceParser.consumeParameter(stream).toString(), "abcde");
     }
@@ -158,7 +158,7 @@ public class TestCommandParser {
     }
 
     @Test
-    public void testConsumeCountError1() {
+    public void testConsumeCountError1() throws EOFException {
         InputStream stream = new ByteArrayInputStream("$12\r\n".getBytes());
         try {
             SliceParser.consumeCount(stream);
@@ -169,7 +169,7 @@ public class TestCommandParser {
     }
 
     @Test
-    public void testConsumeCountError2() {
+    public void testConsumeCountError2() throws EOFException {
         InputStream stream = new ByteArrayInputStream("*12\ra".getBytes());
         try {
             SliceParser.consumeCount(stream);
@@ -185,7 +185,7 @@ public class TestCommandParser {
         try {
             SliceParser.consumeParameter(stream);
             fail();
-        } catch (ParseErrorException e) {
+        } catch (ParseErrorException | EOFException e) {
             // OK
         }
     }
@@ -196,7 +196,7 @@ public class TestCommandParser {
         try {
             SliceParser.consumeParameter(stream);
             fail();
-        } catch (ParseErrorException e) {
+        } catch (ParseErrorException | EOFException e) {
             // OK
         }
     }
@@ -207,7 +207,7 @@ public class TestCommandParser {
         try {
             SliceParser.consumeParameter(stream);
             fail();
-        } catch (ParseErrorException e) {
+        } catch (ParseErrorException | EOFException e) {
             // OK
         }
     }
@@ -218,7 +218,7 @@ public class TestCommandParser {
         try {
             SliceParser.consumeParameter(stream);
             fail();
-        } catch (ParseErrorException e) {
+        } catch (ParseErrorException | EOFException e) {
             // OK
         }
     }

--- a/src/test/java/com/github/fppt/jedismock/TestRedisServer.java
+++ b/src/test/java/com/github/fppt/jedismock/TestRedisServer.java
@@ -84,4 +84,29 @@ public class TestRedisServer {
             server.stop();
         }
     }
+
+    @Test
+    public void testClientClosesConnection() throws IOException, InterruptedException {
+        RedisServer server = RedisServer.newRedisServer();
+        server.start();
+
+        Jedis jedis = new Jedis(server.getHost(), server.getBindPort());
+        assertEquals("PONG", jedis.ping());
+        assertEquals(1, server.getConnectedClients().size());
+
+        jedis.close();
+
+        // give the thread a little bit of time to complete (1 second)
+        for (int retry = 0; retry < 10; retry++) {
+            if (server.getConnectedClients().isEmpty()) {
+                break;
+            } else {
+                Thread.sleep(100);
+            }
+        }
+
+        assertEquals(0, server.getConnectedClients().size());
+
+        server.stop();
+    }
 }


### PR DESCRIPTION
Without this change, a client going away without issuing a QUIT will cause the RedisClient to spin forever, throwing EOFExceptions that are turned into ParseErrorException, but it never stops.

The main change is allowing `EOFException` to bubble up to the `RedisClient`, where we'll now close the streams and unset the running flag, so the thread can exit.

The `Collection<RedisClient>` was added so we can test this easily, but not exposed to the public API.