### PR TITLE
fix #135

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,11 @@
             <name>Filipe Peliz Pinto Teixeira</name>
             <email>fppintoteixeira@gmail.com</email>
         </developer>
-
+        <developer>
+            <id>inponomarev</id>
+            <name>Ivan Ponomarev</name>
+            <email>iponomarev@curs.ru</email>
+        </developer>
         <!-- Original developer of library no longer maintaining project (Kudos To You Sir!!)-->
         <developer>
             <id>zxl0714</id>
@@ -94,6 +98,12 @@
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.10.0</version>
             <scope>test</scope>
         </dependency>
         <!-- SLF4J is the logging API all modules should use -->

--- a/src/main/java/com/github/fppt/jedismock/server/RedisClient.java
+++ b/src/main/java/com/github/fppt/jedismock/server/RedisClient.java
@@ -47,10 +47,9 @@ public class RedisClient implements Runnable {
 
     public void run() {
         int count = 0;
-        while (running.get()) {
+        while (running.get() && !socket.isClosed()) {
             Optional<RedisCommand> command = nextCommand();
-
-            if(command.isPresent()){
+            if (command.isPresent()) {
                 Slice response = executor.execCommand(command.get());
                 sendResponse(response, command.toString());
 
@@ -69,10 +68,10 @@ public class RedisClient implements Runnable {
      *
      * @return The next command on the stream if one was issues
      */
-    private Optional<RedisCommand> nextCommand(){
+    private Optional<RedisCommand> nextCommand() {
         try {
             return Optional.of(RedisCommandParser.parse(in));
-        } catch (ParseErrorException e){
+        } catch (ParseErrorException e) {
             return Optional.empty(); // This simply means there is no next command
         }
     }
@@ -80,7 +79,7 @@ public class RedisClient implements Runnable {
     /**
      * Send a response due to a specific command.
      *
-     * @param response The respond to send.
+     * @param response     The respond to send.
      * @param respondingTo The reason for sending this response
      */
     public void sendResponse(Slice response, String respondingTo) {
@@ -88,8 +87,8 @@ public class RedisClient implements Runnable {
             if (!response.equals(Response.SKIP)) {
                 out.write(response.data());
             }
-        } catch (IOException e){
-            LOG.error("unable to send [" + response + "] as response to [" + respondingTo +"]", e);
+        } catch (IOException e) {
+            LOG.error("unable to send [" + response + "] as response to [" + respondingTo + "]", e);
         }
     }
 
@@ -97,7 +96,7 @@ public class RedisClient implements Runnable {
      * Close all the streams used by this client effectively closing the client.
      * Also signals the client to stop working.
      */
-    public void close(){
+    public void close() {
         running.set(false);
         Utils.closeQuietly(socket);
         Utils.closeQuietly(in);

--- a/src/test/java/com/github/fppt/jedismock/server/RedisClientTest.java
+++ b/src/test/java/com/github/fppt/jedismock/server/RedisClientTest.java
@@ -1,0 +1,31 @@
+package com.github.fppt.jedismock.server;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.util.Collections;
+
+class RedisClientTest {
+    Socket s;
+    RedisClient redisClient;
+
+    @BeforeEach
+    void init() throws IOException {
+        s = Mockito.mock(Socket.class);
+        Mockito.when(s.getInputStream()).thenReturn(Mockito.mock(InputStream.class));
+        Mockito.when(s.getOutputStream()).thenReturn(Mockito.mock(OutputStream.class));
+        redisClient = new RedisClient(Collections.emptyMap(), s, ServiceOptions.defaultOptions());
+    }
+
+    @Test
+    void testClosedSocket() throws IOException {
+        Mockito.when(s.isClosed()).thenReturn(true);
+        redisClient.run();
+    }
+
+}


### PR DESCRIPTION
Fixes #135: guards RedisClient from further execution when the socket is closed. It also provides a much simpler solution for the problem than in #106