### PR TITLE
When calling RedisServer.stop, disconnect existing clients (fix #202)

### DIFF
--- a/src/main/java/com/github/fppt/jedismock/RedisServer.java
+++ b/src/main/java/com/github/fppt/jedismock/RedisServer.java
@@ -63,6 +63,7 @@ public class RedisServer {
     public void stop() throws IOException {
         Objects.requireNonNull(service);
         service.stop();
+        service = null;
         try {
             serviceFinalization.get();
         } catch (ExecutionException e) {

--- a/src/main/java/com/github/fppt/jedismock/server/RedisService.java
+++ b/src/main/java/com/github/fppt/jedismock/server/RedisService.java
@@ -5,10 +5,11 @@ import com.github.fppt.jedismock.storage.RedisBase;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.Socket;
-import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -21,7 +22,7 @@ public class RedisService implements Callable<Void> {
     private final Map<Integer, RedisBase> redisBases;
     private final ServiceOptions options;
     private final ExecutorService threadPool = Executors.newCachedThreadPool();
-    private ArrayList<RedisClient> clients = new ArrayList<>();
+    private final List<RedisClient> clients = new CopyOnWriteArrayList<>();
 
     public RedisService(int bindPort, Map<Integer, RedisBase> redisBases, ServiceOptions options) throws IOException {
         Objects.requireNonNull(redisBases);
@@ -35,7 +36,7 @@ public class RedisService implements Callable<Void> {
     public Void call() throws IOException {
         while (!server.isClosed()) {
             Socket socket = server.accept();
-            RedisClient rc = new RedisClient(redisBases, socket, options);
+            RedisClient rc = new RedisClient(redisBases, socket, options, clients::remove);
             clients.add(rc);
             threadPool.submit(rc);
         }
@@ -47,9 +48,8 @@ public class RedisService implements Callable<Void> {
     }
 
     public void stop() throws IOException {
-        clients.forEach(client -> {
-            client.close();
-        });
+        clients.forEach(RedisClient::close);
         server.close();
+        threadPool.shutdownNow();
     }
 }

--- a/src/test/java/com/github/fppt/jedismock/TestRedisServer.java
+++ b/src/test/java/com/github/fppt/jedismock/TestRedisServer.java
@@ -2,6 +2,7 @@ package com.github.fppt.jedismock;
 
 import org.junit.jupiter.api.Test;
 import redis.clients.jedis.Jedis;
+import redis.clients.jedis.exceptions.JedisConnectionException;
 
 import java.io.IOException;
 import java.net.BindException;
@@ -62,6 +63,22 @@ public class TestRedisServer {
             assertEquals("PONG", jedis.ping());
 
             server.stop();
+            assertThrows(JedisConnectionException.class, () -> {
+                jedis.ping();
+            });
+        }
+
+        RedisServer server = RedisServer.newRedisServer();
+        for (int i = 0; i < 20; i ++){
+            server.start();
+
+            Jedis jedis = new Jedis(server.getHost(), server.getBindPort());
+            assertEquals("PONG", jedis.ping());
+
+            server.stop();
+            assertThrows(JedisConnectionException.class, () -> {
+                jedis.ping();
+            });
         }
     }
 }

--- a/src/test/java/com/github/fppt/jedismock/server/RedisClientTest.java
+++ b/src/test/java/com/github/fppt/jedismock/server/RedisClientTest.java
@@ -9,7 +9,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Socket;
 import java.util.Collections;
-import java.util.concurrent.locks.ReentrantLock;
 
 class RedisClientTest {
     Socket s;
@@ -20,7 +19,8 @@ class RedisClientTest {
         s = Mockito.mock(Socket.class);
         Mockito.when(s.getInputStream()).thenReturn(Mockito.mock(InputStream.class));
         Mockito.when(s.getOutputStream()).thenReturn(Mockito.mock(OutputStream.class));
-        redisClient = new RedisClient(Collections.emptyMap(), s, ServiceOptions.defaultOptions());
+        redisClient = new RedisClient(Collections.emptyMap(), s, ServiceOptions.defaultOptions(), c -> {
+        });
     }
 
     @Test

--- a/src/test/java/com/github/fppt/jedismock/server/TestRedisOperationExecutor.java
+++ b/src/test/java/com/github/fppt/jedismock/server/TestRedisOperationExecutor.java
@@ -89,7 +89,8 @@ public class TestRedisOperationExecutor {
         Map<Integer, RedisBase> redisBases = new HashMap<>();
         redisBases.put(0, new RedisBase());
         RedisClient redisClient = new RedisClient(redisBases,
-                mockSocket, ServiceOptions.defaultOptions());
+                mockSocket, ServiceOptions.defaultOptions(), c -> {
+        });
         OperationExecutorState state = new OperationExecutorState(redisClient, redisBases);
         executor = new RedisOperationExecutor(state);
     }


### PR DESCRIPTION
* close client sockets in RedisService
* set service to null in RedisServer after calling stop
* update test to handle exception in Jedis client after calling RedisServer.stop