### PR TITLE
fix handling of curly braces in KEYS

### DIFF
--- a/src/main/java/com/github/fppt/jedismock/Utils.java
+++ b/src/main/java/com/github/fppt/jedismock/Utils.java
@@ -82,6 +82,9 @@ public class Utils {
                 case '\\':
                     out.append("\\\\");
                     break;
+                case '{':
+                    out.append("\\{");
+                    break;
                 default:
                     out.append(c);
             }

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/keys/KeysOperationsTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/keys/KeysOperationsTest.java
@@ -99,4 +99,13 @@ public class KeysOperationsTest {
         //Check that the value is still there
         assertEquals("v", jedis.get("a"));
     }
+
+    @TestTemplate
+    public void handleCurlyBraces(Jedis jedis) {
+        jedis.mset("{hashslot}:one", "1", "{hashslot}:two", "2", "three", "3");
+
+        Set<String> results = jedis.keys("{hashslot}:*");
+        assertEquals(2, results.size());
+        assertTrue(results.contains("{hashslot}:one") && results.contains("{hashslot}:two"));
+    }
 }


### PR DESCRIPTION
In redis clusters, you can put curly braces around a part of the key to make sure some keys go into the same hash slot.
They have a special meaning in regex, but not for redis, so they must be escaped.
When transforming a key-glob `{hashslot}:abc` with `createRegexFromGlob`, this was not done, leading to `java.util.regex.PatternSyntaxException: Illegal repetition near index 0 ^{testTenant::testNamespace::}.*$`