### PR TITLE
Fix `MULTI`/`EXEC` and `FLUSHALL` semantics

### DIFF
--- a/src/main/java/com/github/fppt/jedismock/operations/server/FlushAll.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/server/FlushAll.java
@@ -6,7 +6,7 @@ import com.github.fppt.jedismock.server.Response;
 import com.github.fppt.jedismock.datastructures.Slice;
 import com.github.fppt.jedismock.storage.OperationExecutorState;
 
-@RedisCommand(value = "flushall", transactional = false)
+@RedisCommand(value = "flushall")
 class FlushAll implements RedisOperation {
     private final OperationExecutorState state;
 

--- a/src/main/java/com/github/fppt/jedismock/operations/server/MockExecutor.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/server/MockExecutor.java
@@ -41,10 +41,12 @@ public class MockExecutor {
                         return Response.clientResponse(name, operation.execute());
                     }
                 } else {
+                    state.errorTransaction();
                     return Response.error(String.format("Unsupported operation: %s", name));
                 }
             } catch (Exception e) {
                 LOG.error("Malformed request", e);
+                state.errorTransaction();
                 return Response.error(e.getMessage());
             }
         }

--- a/src/main/java/com/github/fppt/jedismock/operations/transactions/Multi.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/transactions/Multi.java
@@ -10,13 +10,17 @@ import com.github.fppt.jedismock.storage.OperationExecutorState;
 public class Multi implements RedisOperation {
     private final OperationExecutorState state;
 
-    Multi(OperationExecutorState state){
+    Multi(OperationExecutorState state) {
         this.state = state;
     }
 
     @Override
     public Slice execute() {
-        state.newTransaction();
-        return Response.OK;
+        if (state.isTransactionModeOn()) {
+            return Response.error("ERR MULTI calls can not be nested");
+        } else {
+            state.transactionMode(true);
+            return Response.OK;
+        }
     }
 }

--- a/src/main/java/com/github/fppt/jedismock/operations/transactions/Watch.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/transactions/Watch.java
@@ -21,7 +21,11 @@ public class Watch implements RedisOperation {
 
     @Override
     public Slice execute() {
-        state.watch(keys);
-        return Response.OK;
+        if (state.isTransactionModeOn()) {
+            return Response.error("ERR WATCH inside MULTI is not allowed");
+        } else {
+            state.watch(keys);
+            return Response.OK;
+        }
     }
 }

--- a/src/main/java/com/github/fppt/jedismock/storage/ExpiringKeyValueStorage.java
+++ b/src/main/java/com/github/fppt/jedismock/storage/ExpiringKeyValueStorage.java
@@ -22,7 +22,7 @@ public class ExpiringKeyValueStorage {
         return values;
     }
 
-    public Map<Slice, Long> ttls()  {
+    public Map<Slice, Long> ttls() {
         return ttls;
     }
 
@@ -48,7 +48,7 @@ public class ExpiringKeyValueStorage {
 
         storedData.remove(key2);
 
-        if(storedData.isEmpty()) {
+        if (storedData.isEmpty()) {
             values.remove(key1);
         }
 
@@ -58,12 +58,17 @@ public class ExpiringKeyValueStorage {
     }
 
     public void clear() {
+        for (Slice key : values().keySet()) {
+            if (!isKeyOutdated(key)) {
+                keyChangeNotifier.accept(key);
+            }
+        }
         values().clear();
         ttls().clear();
     }
 
     public RMDataStructure getValue(Slice key) {
-        if(!verifyKey(key)) {
+        if (!verifyKey(key)) {
             return null;
         }
         return values().get(key);
@@ -71,7 +76,7 @@ public class ExpiringKeyValueStorage {
 
     private boolean verifyKey(Slice key) {
         Objects.requireNonNull(key);
-        if(!values().containsKey(key)) {
+        if (!values().containsKey(key)) {
             return false;
         }
 
@@ -132,7 +137,7 @@ public class ExpiringKeyValueStorage {
         Objects.requireNonNull(value);
         RMHash mapByKey;
 
-        if(!values.containsKey(key1)) {
+        if (!values.containsKey(key1)) {
             mapByKey = new RMHash();
             values.put(key1, mapByKey);
         } else {
@@ -144,7 +149,7 @@ public class ExpiringKeyValueStorage {
 
     private RMHash getRMSortedSet(Slice key) {
         RMDataStructure valueByKey = values.get(key);
-        if(!isSortedSetValue(valueByKey)) {
+        if (!isSortedSetValue(valueByKey)) {
             valueByKey.raiseTypeCastException();
         }
 


### PR DESCRIPTION
1. `FLUSHALL` should be queued inside MULTI-EXEC transaction
2. `FLUSHALL` must notify all the WAIT-monitored keys
3. `MULTI` and `WAIT` inside transaction should return errors but not discard the transaction
4. In case there are errors when collecting the transaction queue, the whole transaction is not executed