### PR TITLE
Cancel blocking commands on client disconnect and serve blocked clients in FIFO order

### DIFF
--- a/native_tests/linux/tests/unit/type/list.tcl
+++ b/native_tests/linux/tests/unit/type/list.tcl
@@ -331,50 +331,50 @@ start_server {
         r lrange blist 0 -1
     } {a b c}
 
-#    test "BRPOPLPUSH with multiple blocked clients" {
-#        set rd1 [redis_deferring_client]
-#        set rd2 [redis_deferring_client]
-#        r del blist target1 target2
-#        r set target1 nolist
-#        $rd1 brpoplpush blist target1 0
-#        $rd2 brpoplpush blist target2 0
-#        r lpush blist foo
-#
-#        assert_error "WRONGTYPE*" {$rd1 read}
-#        assert_equal {foo} [$rd2 read]
-#        assert_equal {foo} [r lrange target2 0 -1]
-#    }
+    test "BRPOPLPUSH with multiple blocked clients" {
+        set rd1 [redis_deferring_client]
+        set rd2 [redis_deferring_client]
+        r del blist target1 target2
+        r set target1 nolist
+        $rd1 brpoplpush blist target1 0
+        $rd2 brpoplpush blist target2 0
+        r lpush blist foo
 
-#    test "Linked BRPOPLPUSH" {
-#      set rd1 [redis_deferring_client]
-#      set rd2 [redis_deferring_client]
-#
-#      r del list1 list2 list3
-#
-#      $rd1 brpoplpush list1 list2 0
-#      $rd2 brpoplpush list2 list3 0
-#
-#      r rpush list1 foo
-#
-#      assert_equal {} [r lrange list1 0 -1]
-#      assert_equal {} [r lrange list2 0 -1]
-#      assert_equal {foo} [r lrange list3 0 -1]
-#    }
+        assert_error "WRONGTYPE*" {$rd1 read}
+        assert_equal {foo} [$rd2 read]
+        assert_equal {foo} [r lrange target2 0 -1]
+    }
 
-#    test "Circular BRPOPLPUSH" {
-#      set rd1 [redis_deferring_client]
-#      set rd2 [redis_deferring_client]
-#
-#      r del list1 list2
-#
-#      $rd1 brpoplpush list1 list2 0
-#      $rd2 brpoplpush list2 list1 0
-#
-#      r rpush list1 foo
-#
-#      assert_equal {foo} [r lrange list1 0 -1]
-#      assert_equal {} [r lrange list2 0 -1]
-#    }
+    test "Linked BRPOPLPUSH" {
+      set rd1 [redis_deferring_client]
+      set rd2 [redis_deferring_client]
+
+      r del list1 list2 list3
+
+      $rd1 brpoplpush list1 list2 0
+      $rd2 brpoplpush list2 list3 0
+
+      r rpush list1 foo
+
+      assert_equal {} [r lrange list1 0 -1]
+      assert_equal {} [r lrange list2 0 -1]
+      assert_equal {foo} [r lrange list3 0 -1]
+    }
+
+    test "Circular BRPOPLPUSH" {
+      set rd1 [redis_deferring_client]
+      set rd2 [redis_deferring_client]
+
+      r del list1 list2
+
+      $rd1 brpoplpush list1 list2 0
+      $rd2 brpoplpush list2 list1 0
+
+      r rpush list1 foo
+
+      assert_equal {foo} [r lrange list1 0 -1]
+      assert_equal {} [r lrange list2 0 -1]
+    }
 
     test "Self-referential BRPOPLPUSH" {
       set rd [redis_deferring_client]

--- a/native_tests/linux/tests/unit/type/list.tcl
+++ b/native_tests/linux/tests/unit/type/list.tcl
@@ -337,7 +337,9 @@ start_server {
         r del blist target1 target2
         r set target1 nolist
         $rd1 brpoplpush blist target1 0
+        wait_for_blocked_clients_count 1
         $rd2 brpoplpush blist target2 0
+        wait_for_blocked_clients_count 2
         r lpush blist foo
 
         assert_error "WRONGTYPE*" {$rd1 read}
@@ -345,6 +347,11 @@ start_server {
         assert_equal {foo} [r lrange target2 0 -1]
     }
 
+    # Known unsupported: jedis-mock serves blocked clients on their own
+    # threads, so a BRPOPLPUSH cascade (rd1 pushing the value that unblocks
+    # rd2) completes asynchronously. The assertions below race that cascade,
+    # whereas real Redis serves blocked clients to fixpoint inside the RPUSH.
+    # Re-enable once blocked-client serving is driven synchronously.
 #    test "Linked BRPOPLPUSH" {
 #      set rd1 [redis_deferring_client]
 #      set rd2 [redis_deferring_client]

--- a/native_tests/linux/tests/unit/type/list.tcl
+++ b/native_tests/linux/tests/unit/type/list.tcl
@@ -345,36 +345,36 @@ start_server {
         assert_equal {foo} [r lrange target2 0 -1]
     }
 
-    test "Linked BRPOPLPUSH" {
-      set rd1 [redis_deferring_client]
-      set rd2 [redis_deferring_client]
+#    test "Linked BRPOPLPUSH" {
+#      set rd1 [redis_deferring_client]
+#      set rd2 [redis_deferring_client]
+#
+#      r del list1 list2 list3
+#
+#      $rd1 brpoplpush list1 list2 0
+#      $rd2 brpoplpush list2 list3 0
+#
+#      r rpush list1 foo
+#
+#      assert_equal {} [r lrange list1 0 -1]
+#      assert_equal {} [r lrange list2 0 -1]
+#      assert_equal {foo} [r lrange list3 0 -1]
+#    }
 
-      r del list1 list2 list3
-
-      $rd1 brpoplpush list1 list2 0
-      $rd2 brpoplpush list2 list3 0
-
-      r rpush list1 foo
-
-      assert_equal {} [r lrange list1 0 -1]
-      assert_equal {} [r lrange list2 0 -1]
-      assert_equal {foo} [r lrange list3 0 -1]
-    }
-
-    test "Circular BRPOPLPUSH" {
-      set rd1 [redis_deferring_client]
-      set rd2 [redis_deferring_client]
-
-      r del list1 list2
-
-      $rd1 brpoplpush list1 list2 0
-      $rd2 brpoplpush list2 list1 0
-
-      r rpush list1 foo
-
-      assert_equal {foo} [r lrange list1 0 -1]
-      assert_equal {} [r lrange list2 0 -1]
-    }
+#    test "Circular BRPOPLPUSH" {
+#      set rd1 [redis_deferring_client]
+#      set rd2 [redis_deferring_client]
+#
+#      r del list1 list2
+#
+#      $rd1 brpoplpush list1 list2 0
+#      $rd2 brpoplpush list2 list1 0
+#
+#      r rpush list1 foo
+#
+#      assert_equal {foo} [r lrange list1 0 -1]
+#      assert_equal {} [r lrange list2 0 -1]
+#    }
 
     test "Self-referential BRPOPLPUSH" {
       set rd [redis_deferring_client]

--- a/src/main/java/com/github/fppt/jedismock/RedisClient.java
+++ b/src/main/java/com/github/fppt/jedismock/RedisClient.java
@@ -95,6 +95,30 @@ public final class RedisClient implements Runnable {
     }
 
     /**
+     * Best-effort liveness probe, safe to call from a blocking operation that
+     * holds the shared data lock (it neither reads the input stream nor blocks).
+     * It sends a single TCP urgent (out-of-band) byte: a live peer silently
+     * discards it (SO_OOBINLINE is off by default, so it never enters the RESP
+     * stream), while a peer that has gone away makes the write fail. This lets
+     * blocking commands (BLPOP, BRPOPLPUSH, blocking XREAD, …) notice that their
+     * client disconnected and bail out instead of consuming data meant for a
+     * later client on a reused key.
+     *
+     * @return {@code true} if the connection still appears to be alive.
+     */
+    public boolean isConnected() {
+        if (!running.get() || socket.isClosed() || !socket.isConnected()) {
+            return false;
+        }
+        try {
+            socket.sendUrgentData(0xFF);
+            return true;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    /**
      * Close all the streams used by this client effectively closing the client.
      * Also signals the client to stop working.
      */

--- a/src/main/java/com/github/fppt/jedismock/RedisClient.java
+++ b/src/main/java/com/github/fppt/jedismock/RedisClient.java
@@ -42,7 +42,7 @@ public final class RedisClient implements Runnable {
         Objects.requireNonNull(onClose);
         this.server = server;
         OperationExecutorState state = new OperationExecutorState(this,
-                server.getRedisBases());
+                server.getRedisBases(), server.getBlockingManager());
         this.executor = new RedisOperationExecutor(state);
         this.socket = socket;
         this.in = socket.getInputStream();

--- a/src/main/java/com/github/fppt/jedismock/RedisServer.java
+++ b/src/main/java/com/github/fppt/jedismock/RedisServer.java
@@ -2,6 +2,7 @@ package com.github.fppt.jedismock;
 
 import com.github.fppt.jedismock.operations.CommandFactory;
 import com.github.fppt.jedismock.server.ServiceOptions;
+import com.github.fppt.jedismock.storage.BlockingManager;
 import com.github.fppt.jedismock.storage.RedisBase;
 
 import java.io.IOException;
@@ -30,6 +31,7 @@ public class RedisServer {
     private final int bindPort;
     private final InetAddress bindAddress;
     private final Map<Integer, RedisBase> redisBases;
+    private final BlockingManager blockingManager = new BlockingManager();
     private volatile ExecutorService singleThreadPool;
     private volatile RedisServiceJob service;
     private volatile Clock clock = Clock.systemDefaultZone();
@@ -116,6 +118,10 @@ public class RedisServer {
 
     Map<Integer, RedisBase> getRedisBases() {
         return redisBases;
+    }
+
+    BlockingManager getBlockingManager() {
+        return blockingManager;
     }
 
     public ServiceOptions options() {

--- a/src/main/java/com/github/fppt/jedismock/operations/AbstractBPop.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/AbstractBPop.java
@@ -4,6 +4,7 @@ import com.github.fppt.jedismock.datastructures.Slice;
 import com.github.fppt.jedismock.exception.WrongValueTypeException;
 import com.github.fppt.jedismock.server.Response;
 import com.github.fppt.jedismock.server.SliceParser;
+import com.github.fppt.jedismock.storage.BlockingManager;
 import com.github.fppt.jedismock.storage.OperationExecutorState;
 import com.github.fppt.jedismock.storage.RedisBase;
 
@@ -25,12 +26,14 @@ public abstract class AbstractBPop extends AbstractRedisOperation {
     private final Object lock;
     private final boolean isInTransaction;
     private final OperationExecutorState state;
+    private final BlockingManager blockingManager;
 
     protected AbstractBPop(OperationExecutorState state, List<Slice> params) {
         super(state.base(), params);
         this.lock = state.lock();
         this.isInTransaction = state.isTransactionModeOn();
         this.state = state;
+        this.blockingManager = state.blockingManager();
     }
 
     @Override
@@ -55,27 +58,48 @@ public abstract class AbstractBPop extends AbstractRedisOperation {
 
         Slice source = getKey(keys, true);
 
+        if (source != null || isInTransaction) {
+            //Element already available, or inside MULTI where we must not block.
+            if (source == null) {
+                return Response.NULL_ARRAY;
+            }
+            return popper(Collections.singletonList(source));
+        }
+
         long waitEnd = System.nanoTime() + timeoutNanos;
         long waitTimeNanos;
         //Remember why the loop ended: we must not re-probe the connection at
         //delivery time. A transient liveness-probe failure right when data has
         //arrived would otherwise drop a legitimate reply and hang the client.
         boolean connected = true;
+        //Register as a FIFO waiter on every key so that, among several clients
+        //blocked on the same key, the oldest is served first (matching real
+        //Redis). Without this, notifyAll() lets an arbitrary waiter steal the
+        //element, which can leave an older waiter blocked forever.
+        long ticket = blockingManager.nextTicket();
+        blockingManager.register(ticket, keys);
         try {
-            while (source == null &&
-                    !isInTransaction &&
-                    (connected = state.isClientConnected()) &&
+            while ((connected = state.isClientConnected()) &&
                     (waitTimeNanos = timeoutNanos == 0 ? Long.MAX_VALUE : waitEnd - System.nanoTime()) >= 0) {
+                Slice candidate = getKey(keys, false);
+                if (candidate != null && blockingManager.isFirst(ticket, candidate)) {
+                    source = candidate;
+                    break;
+                }
                 long remainingMillis = waitTimeNanos / 1_000_000;
                 long waitMillis = Math.min(remainingMillis, POLL_MILLIS);
                 int waitNano = waitMillis == remainingMillis ? (int) (waitTimeNanos % 1_000_000) : 0;
                 lock.wait(waitMillis, waitNano);
-                source = getKey(keys, false);
             }
         } catch (InterruptedException e) {
             //wait interrupted prematurely
             Thread.currentThread().interrupt();
             return Response.NULL;
+        } finally {
+            blockingManager.unregister(ticket, keys);
+            //Hand the turn to the next-in-line waiter, which re-evaluates whether
+            //it is now the oldest one able to claim an element.
+            lock.notifyAll();
         }
         if (!connected) {
             //Client disconnected while blocked: don't consume anything, don't reply.

--- a/src/main/java/com/github/fppt/jedismock/operations/AbstractBPop.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/AbstractBPop.java
@@ -13,15 +13,24 @@ import java.util.List;
 import static com.github.fppt.jedismock.Utils.toNanoTimeout;
 
 public abstract class AbstractBPop extends AbstractRedisOperation {
+    /**
+     * Upper bound on a single {@code wait()} so the loop wakes up periodically
+     * to re-check whether the client is still connected, even with no notify
+     * and an infinite ({@code timeout 0}) block.
+     */
+    private static final long POLL_MILLIS = 100L;
+
     protected long timeoutNanos;
     protected List<Slice> keys;
     private final Object lock;
     private final boolean isInTransaction;
+    private final OperationExecutorState state;
 
     protected AbstractBPop(OperationExecutorState state, List<Slice> params) {
         super(state.base(), params);
         this.lock = state.lock();
         this.isInTransaction = state.isTransactionModeOn();
+        this.state = state;
     }
 
     @Override
@@ -51,9 +60,11 @@ public abstract class AbstractBPop extends AbstractRedisOperation {
         try {
             while (source == null &&
                     !isInTransaction &&
-                    (waitTimeNanos = timeoutNanos == 0 ? 0 : waitEnd - System.nanoTime()) >= 0) {
-                long waitMillis = waitTimeNanos / 1_000_000 > 1000 ? 1000 : waitTimeNanos / 1_000_000;
-                int waitNano = (int) (waitTimeNanos % 1_000_000);
+                    state.isClientConnected() &&
+                    (waitTimeNanos = timeoutNanos == 0 ? Long.MAX_VALUE : waitEnd - System.nanoTime()) >= 0) {
+                long remainingMillis = waitTimeNanos / 1_000_000;
+                long waitMillis = Math.min(remainingMillis, POLL_MILLIS);
+                int waitNano = waitMillis == remainingMillis ? (int) (waitTimeNanos % 1_000_000) : 0;
                 lock.wait(waitMillis, waitNano);
                 source = getKey(keys, false);
             }
@@ -61,6 +72,10 @@ public abstract class AbstractBPop extends AbstractRedisOperation {
             //wait interrupted prematurely
             Thread.currentThread().interrupt();
             return Response.NULL;
+        }
+        if (!state.isClientConnected()) {
+            //Client disconnected while blocked: don't consume anything, don't reply.
+            return Response.SKIP;
         }
         if (source == null) {
             return Response.NULL_ARRAY;

--- a/src/main/java/com/github/fppt/jedismock/operations/AbstractBPop.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/AbstractBPop.java
@@ -76,13 +76,11 @@ public abstract class AbstractBPop extends AbstractRedisOperation {
         //blocked on the same key, the oldest is served first (matching real
         //Redis). Without this, notifyAll() lets an arbitrary waiter steal the
         //element, which can leave an older waiter blocked forever.
-        long ticket = blockingManager.nextTicket();
-        blockingManager.register(ticket, keys);
-        try {
+        try (BlockingManager.Ticket ticket = blockingManager.register(keys)) {
             while ((connected = state.isClientConnected()) &&
                     (waitTimeNanos = timeoutNanos == 0 ? Long.MAX_VALUE : waitEnd - System.nanoTime()) >= 0) {
                 Slice candidate = getKey(keys, false);
-                if (candidate != null && blockingManager.isFirst(ticket, candidate)) {
+                if (candidate != null && ticket.isFirst(candidate)) {
                     source = candidate;
                     break;
                 }
@@ -96,9 +94,9 @@ public abstract class AbstractBPop extends AbstractRedisOperation {
             Thread.currentThread().interrupt();
             return Response.NULL;
         } finally {
-            blockingManager.unregister(ticket, keys);
             //Hand the turn to the next-in-line waiter, which re-evaluates whether
-            //it is now the oldest one able to claim an element.
+            //it is now the oldest one able to claim an element. The ticket has
+            //already been unregistered by try-with-resources.
             lock.notifyAll();
         }
         if (!connected) {

--- a/src/main/java/com/github/fppt/jedismock/operations/AbstractBPop.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/AbstractBPop.java
@@ -57,10 +57,14 @@ public abstract class AbstractBPop extends AbstractRedisOperation {
 
         long waitEnd = System.nanoTime() + timeoutNanos;
         long waitTimeNanos;
+        //Remember why the loop ended: we must not re-probe the connection at
+        //delivery time. A transient liveness-probe failure right when data has
+        //arrived would otherwise drop a legitimate reply and hang the client.
+        boolean connected = true;
         try {
             while (source == null &&
                     !isInTransaction &&
-                    state.isClientConnected() &&
+                    (connected = state.isClientConnected()) &&
                     (waitTimeNanos = timeoutNanos == 0 ? Long.MAX_VALUE : waitEnd - System.nanoTime()) >= 0) {
                 long remainingMillis = waitTimeNanos / 1_000_000;
                 long waitMillis = Math.min(remainingMillis, POLL_MILLIS);
@@ -73,7 +77,7 @@ public abstract class AbstractBPop extends AbstractRedisOperation {
             Thread.currentThread().interrupt();
             return Response.NULL;
         }
-        if (!state.isClientConnected()) {
+        if (!connected) {
             //Client disconnected while blocked: don't consume anything, don't reply.
             return Response.SKIP;
         }

--- a/src/main/java/com/github/fppt/jedismock/operations/lists/BRPopLPush.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/lists/BRPopLPush.java
@@ -61,13 +61,11 @@ class BRPopLPush extends RPopLPush {
         //this, notifyAll() lets an arbitrary waiter steal the element, which can
         //leave an older waiter blocked forever.
         List<Slice> waitKeys = Collections.singletonList(source);
-        long ticket = blockingManager.nextTicket();
-        blockingManager.register(ticket, waitKeys);
         boolean acquired = false;
-        try {
+        try (BlockingManager.Ticket ticket = blockingManager.register(waitKeys)) {
             while ((connected = state.isClientConnected()) &&
                     (waitTimeNanos = timeoutNanos == 0 ? Long.MAX_VALUE : waitEnd - System.nanoTime()) >= 0) {
-                if (getCount(source) != 0 && blockingManager.isFirst(ticket, source)) {
+                if (getCount(source) != 0 && ticket.isFirst(source)) {
                     acquired = true;
                     break;
                 }
@@ -80,9 +78,9 @@ class BRPopLPush extends RPopLPush {
             //wait interrupted prematurely
             Thread.currentThread().interrupt();
         } finally {
-            blockingManager.unregister(ticket, waitKeys);
             //Hand the turn to the next-in-line waiter, which re-evaluates whether
-            //it is now the oldest one able to claim the element.
+            //it is now the oldest one able to claim the element. The ticket has
+            //already been unregistered by try-with-resources.
             lock.notifyAll();
         }
         //Only claim the element if we actually won our turn; otherwise behave as

--- a/src/main/java/com/github/fppt/jedismock/operations/lists/BRPopLPush.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/lists/BRPopLPush.java
@@ -21,6 +21,10 @@ class BRPopLPush extends RPopLPush {
     private static final long POLL_MILLIS = 100L;
 
     private long count = 0L;
+    //Records why the wait loop ended, so response() doesn't re-probe the
+    //connection at delivery time (a transient probe failure would otherwise
+    //drop a legitimate reply and hang the client).
+    private boolean connected = true;
     private final Object lock;
     private final boolean isInTransaction;
     private final OperationExecutorState state;
@@ -46,7 +50,7 @@ class BRPopLPush extends RPopLPush {
         try {
             while (count == 0L &&
                     !isInTransaction &&
-                    state.isClientConnected() &&
+                    (connected = state.isClientConnected()) &&
                     (waitTimeNanos = timeoutNanos == 0 ? Long.MAX_VALUE : waitEnd - System.nanoTime()) >= 0) {
                 long remainingMillis = waitTimeNanos / 1_000_000;
                 long waitMillis = Math.min(remainingMillis, POLL_MILLIS);
@@ -61,7 +65,7 @@ class BRPopLPush extends RPopLPush {
     }
 
     protected Slice response() {
-        if (!state.isClientConnected()) {
+        if (!connected) {
             //Client disconnected while blocked: don't move anything, don't reply.
             return Response.SKIP;
         }

--- a/src/main/java/com/github/fppt/jedismock/operations/lists/BRPopLPush.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/lists/BRPopLPush.java
@@ -13,14 +13,23 @@ import static com.github.fppt.jedismock.Utils.toNanoTimeout;
 
 @RedisCommand("brpoplpush")
 class BRPopLPush extends RPopLPush {
+    /**
+     * Upper bound on a single {@code wait()} so the loop wakes up periodically
+     * to re-check whether the client is still connected, even with no notify
+     * and an infinite ({@code timeout 0}) block.
+     */
+    private static final long POLL_MILLIS = 100L;
+
     private long count = 0L;
     private final Object lock;
     private final boolean isInTransaction;
+    private final OperationExecutorState state;
 
     BRPopLPush(OperationExecutorState state, List<Slice> params) {
         super(state, params);
         this.lock = state.lock();
         this.isInTransaction = state.isTransactionModeOn();
+        this.state = state;
     }
 
     protected void doOptionalWork() {
@@ -37,8 +46,12 @@ class BRPopLPush extends RPopLPush {
         try {
             while (count == 0L &&
                     !isInTransaction &&
-                    (waitTimeNanos = timeoutNanos == 0 ? 0 : waitEnd - System.nanoTime()) >= 0) {
-                lock.wait(waitTimeNanos / 1_000_000, (int) waitTimeNanos % 1_000_000);
+                    state.isClientConnected() &&
+                    (waitTimeNanos = timeoutNanos == 0 ? Long.MAX_VALUE : waitEnd - System.nanoTime()) >= 0) {
+                long remainingMillis = waitTimeNanos / 1_000_000;
+                long waitMillis = Math.min(remainingMillis, POLL_MILLIS);
+                int waitNano = waitMillis == remainingMillis ? (int) (waitTimeNanos % 1_000_000) : 0;
+                lock.wait(waitMillis, waitNano);
                 count = getCount(source);
             }
         } catch (InterruptedException e) {
@@ -48,6 +61,10 @@ class BRPopLPush extends RPopLPush {
     }
 
     protected Slice response() {
+        if (!state.isClientConnected()) {
+            //Client disconnected while blocked: don't move anything, don't reply.
+            return Response.SKIP;
+        }
         if (count != 0) {
             return super.response();
         } else {

--- a/src/main/java/com/github/fppt/jedismock/operations/lists/BRPopLPush.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/lists/BRPopLPush.java
@@ -4,9 +4,11 @@ import com.github.fppt.jedismock.datastructures.Slice;
 import com.github.fppt.jedismock.operations.RedisCommand;
 import com.github.fppt.jedismock.server.Response;
 import com.github.fppt.jedismock.server.SliceParser;
+import com.github.fppt.jedismock.storage.BlockingManager;
 import com.github.fppt.jedismock.storage.OperationExecutorState;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static com.github.fppt.jedismock.Utils.toNanoTimeout;
@@ -28,12 +30,14 @@ class BRPopLPush extends RPopLPush {
     private final Object lock;
     private final boolean isInTransaction;
     private final OperationExecutorState state;
+    private final BlockingManager blockingManager;
 
     BRPopLPush(OperationExecutorState state, List<Slice> params) {
         super(state, params);
         this.lock = state.lock();
         this.isInTransaction = state.isTransactionModeOn();
         this.state = state;
+        this.blockingManager = state.blockingManager();
     }
 
     protected void doOptionalWork() {
@@ -44,24 +48,47 @@ class BRPopLPush extends RPopLPush {
             throw new IllegalArgumentException("ERR timeout is negative");
         }
 
+        count = getCount(source);
+        if (isInTransaction || count != 0) {
+            //Inside MULTI we never block; otherwise the element is already there.
+            return;
+        }
+
         long waitEnd = System.nanoTime() + timeoutNanos;
         long waitTimeNanos;
-        count = getCount(source);
+        //Register as a FIFO waiter so that, among several clients blocked on the
+        //same key, the oldest one is served first (matching real Redis). Without
+        //this, notifyAll() lets an arbitrary waiter steal the element, which can
+        //leave an older waiter blocked forever.
+        List<Slice> waitKeys = Collections.singletonList(source);
+        long ticket = blockingManager.nextTicket();
+        blockingManager.register(ticket, waitKeys);
+        boolean acquired = false;
         try {
-            while (count == 0L &&
-                    !isInTransaction &&
-                    (connected = state.isClientConnected()) &&
+            while ((connected = state.isClientConnected()) &&
                     (waitTimeNanos = timeoutNanos == 0 ? Long.MAX_VALUE : waitEnd - System.nanoTime()) >= 0) {
+                if (getCount(source) != 0 && blockingManager.isFirst(ticket, source)) {
+                    acquired = true;
+                    break;
+                }
                 long remainingMillis = waitTimeNanos / 1_000_000;
                 long waitMillis = Math.min(remainingMillis, POLL_MILLIS);
                 int waitNano = waitMillis == remainingMillis ? (int) (waitTimeNanos % 1_000_000) : 0;
                 lock.wait(waitMillis, waitNano);
-                count = getCount(source);
             }
         } catch (InterruptedException e) {
             //wait interrupted prematurely
             Thread.currentThread().interrupt();
+        } finally {
+            blockingManager.unregister(ticket, waitKeys);
+            //Hand the turn to the next-in-line waiter, which re-evaluates whether
+            //it is now the oldest one able to claim the element.
+            lock.notifyAll();
         }
+        //Only claim the element if we actually won our turn; otherwise behave as
+        //if nothing is available (timed out / disconnected / yielded to an older
+        //waiter) so response() doesn't pop data meant for another client.
+        count = acquired ? getCount(source) : 0;
     }
 
     protected Slice response() {

--- a/src/main/java/com/github/fppt/jedismock/operations/server/Info.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/server/Info.java
@@ -4,12 +4,25 @@ import com.github.fppt.jedismock.operations.RedisCommand;
 import com.github.fppt.jedismock.operations.RedisOperation;
 import com.github.fppt.jedismock.server.Response;
 import com.github.fppt.jedismock.datastructures.Slice;
+import com.github.fppt.jedismock.storage.OperationExecutorState;
 
 @RedisCommand(value = "info", transactional = false)
 class Info implements RedisOperation {
+    private final OperationExecutorState state;
+
+    Info(OperationExecutorState state) {
+        this.state = state;
+    }
+
     @Override
     public Slice execute() {
-        //role:master line is needed for Lettuce client
-        return Response.bulkString(Slice.create("Redis Mock Server Info\nrole:master"));
+        //role:master line is needed for Lettuce client.
+        //blocked_clients is polled by test suites (wait_for_blocked_client) to
+        //synchronize before unblocking a blocking command.
+        String info = "Redis Mock Server Info\r\n"
+                + "role:master\r\n"
+                + "# Clients\r\n"
+                + "blocked_clients:" + state.blockingManager().blockedClients() + "\r\n";
+        return Response.bulkString(Slice.create(info));
     }
 }

--- a/src/main/java/com/github/fppt/jedismock/operations/streams/XRead.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/streams/XRead.java
@@ -8,6 +8,7 @@ import com.github.fppt.jedismock.exception.WrongStreamKeyException;
 import com.github.fppt.jedismock.operations.AbstractRedisOperation;
 import com.github.fppt.jedismock.operations.RedisCommand;
 import com.github.fppt.jedismock.server.Response;
+import com.github.fppt.jedismock.storage.BlockingManager;
 import com.github.fppt.jedismock.storage.OperationExecutorState;
 
 import java.util.ArrayList;
@@ -28,12 +29,14 @@ public class XRead extends AbstractRedisOperation {
     private final Object lock;
     private final boolean isInTransaction;
     private final OperationExecutorState state;
+    private final BlockingManager blockingManager;
 
     public XRead(OperationExecutorState state, List<Slice> params) {
         super(state.base(), params);
         lock = state.lock();
         isInTransaction = state.isTransactionModeOn();
         this.state = state;
+        this.blockingManager = state.blockingManager();
     }
 
     @Override
@@ -112,15 +115,24 @@ public class XRead extends AbstractRedisOperation {
         long waitEnd = System.nanoTime() + blockTimeNanosec;
         long waitTimeNanos;
 
-        if (isBlocking) {
+        if (isBlocking && !isInTransaction) {
             boolean updated = false; // should be unblocked after XADD was invoked
             //Records why the wait loop ended, so we don't re-probe the connection
             //at delivery time (a transient probe failure would otherwise drop a
             //legitimate reply and hang the client).
             boolean connected = true;
-            if (blockTimeNanosec > 0) {
-                try {
-                    while (!isInTransaction && !updated && (connected = state.isClientConnected())
+            //Register so INFO's blocked_clients reflects this waiter (the tcl
+            //suite's wait_for_blocked_client polls it before XADD). Unlike a
+            //list pop, a stream read is non-exclusive — a new entry satisfies
+            //every blocked reader — so there is no FIFO isFirst() check; we only
+            //need the count to be accurate.
+            List<Slice> streamKeys = new ArrayList<>();
+            for (Map.Entry<Slice, StreamId> entry : mapKeyToBeginEntryId) {
+                streamKeys.add(entry.getKey());
+            }
+            try (BlockingManager.Ticket ignored = blockingManager.register(streamKeys)) {
+                if (blockTimeNanosec > 0) {
+                    while (!updated && (connected = state.isClientConnected())
                             && (waitTimeNanos = waitEnd - System.nanoTime()) >= 0) {
                         for (Map.Entry<Slice, StreamId> entry : mapKeyToBeginEntryId) {
                             if (base().exists(entry.getKey())
@@ -139,13 +151,8 @@ public class XRead extends AbstractRedisOperation {
                             lock.wait(500, 0);
                         }
                     }
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    return Response.NULL;
-                }
-            } else {
-                try {
-                    while (!isInTransaction && !updated && (connected = state.isClientConnected())) {
+                } else {
+                    while (!updated && (connected = state.isClientConnected())) {
                         for (Map.Entry<Slice, StreamId> entry : mapKeyToBeginEntryId) {
                             if (base().exists(entry.getKey())
                                     && getStreamFromBaseOrCreateEmpty(entry.getKey())
@@ -158,10 +165,10 @@ public class XRead extends AbstractRedisOperation {
                         }
                         lock.wait(500, 0);
                     }
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    return Response.NULL;
                 }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return Response.NULL;
             }
 
             if (!connected) {

--- a/src/main/java/com/github/fppt/jedismock/operations/streams/XRead.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/streams/XRead.java
@@ -114,9 +114,13 @@ public class XRead extends AbstractRedisOperation {
 
         if (isBlocking) {
             boolean updated = false; // should be unblocked after XADD was invoked
+            //Records why the wait loop ended, so we don't re-probe the connection
+            //at delivery time (a transient probe failure would otherwise drop a
+            //legitimate reply and hang the client).
+            boolean connected = true;
             if (blockTimeNanosec > 0) {
                 try {
-                    while (!isInTransaction && !updated && state.isClientConnected()
+                    while (!isInTransaction && !updated && (connected = state.isClientConnected())
                             && (waitTimeNanos = waitEnd - System.nanoTime()) >= 0) {
                         for (Map.Entry<Slice, StreamId> entry : mapKeyToBeginEntryId) {
                             if (base().exists(entry.getKey())
@@ -141,7 +145,7 @@ public class XRead extends AbstractRedisOperation {
                 }
             } else {
                 try {
-                    while (!isInTransaction && !updated && state.isClientConnected()) {
+                    while (!isInTransaction && !updated && (connected = state.isClientConnected())) {
                         for (Map.Entry<Slice, StreamId> entry : mapKeyToBeginEntryId) {
                             if (base().exists(entry.getKey())
                                     && getStreamFromBaseOrCreateEmpty(entry.getKey())
@@ -160,7 +164,7 @@ public class XRead extends AbstractRedisOperation {
                 }
             }
 
-            if (!state.isClientConnected()) {
+            if (!connected) {
                 //Client disconnected while blocked: don't reply.
                 return Response.SKIP;
             }

--- a/src/main/java/com/github/fppt/jedismock/operations/streams/XRead.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/streams/XRead.java
@@ -27,11 +27,13 @@ import static com.github.fppt.jedismock.datastructures.streams.StreamErrors.XREA
 public class XRead extends AbstractRedisOperation {
     private final Object lock;
     private final boolean isInTransaction;
+    private final OperationExecutorState state;
 
     public XRead(OperationExecutorState state, List<Slice> params) {
         super(state.base(), params);
         lock = state.lock();
         isInTransaction = state.isTransactionModeOn();
+        this.state = state;
     }
 
     @Override
@@ -114,7 +116,8 @@ public class XRead extends AbstractRedisOperation {
             boolean updated = false; // should be unblocked after XADD was invoked
             if (blockTimeNanosec > 0) {
                 try {
-                    while (!isInTransaction && !updated && (waitTimeNanos = waitEnd - System.nanoTime()) >= 0) {
+                    while (!isInTransaction && !updated && state.isClientConnected()
+                            && (waitTimeNanos = waitEnd - System.nanoTime()) >= 0) {
                         for (Map.Entry<Slice, StreamId> entry : mapKeyToBeginEntryId) {
                             if (base().exists(entry.getKey())
                                     && entry.getValue()
@@ -138,7 +141,7 @@ public class XRead extends AbstractRedisOperation {
                 }
             } else {
                 try {
-                    while (!isInTransaction && !updated) {
+                    while (!isInTransaction && !updated && state.isClientConnected()) {
                         for (Map.Entry<Slice, StreamId> entry : mapKeyToBeginEntryId) {
                             if (base().exists(entry.getKey())
                                     && getStreamFromBaseOrCreateEmpty(entry.getKey())
@@ -155,6 +158,11 @@ public class XRead extends AbstractRedisOperation {
                     Thread.currentThread().interrupt();
                     return Response.NULL;
                 }
+            }
+
+            if (!state.isClientConnected()) {
+                //Client disconnected while blocked: don't reply.
+                return Response.SKIP;
             }
         }
 

--- a/src/main/java/com/github/fppt/jedismock/storage/BlockingManager.java
+++ b/src/main/java/com/github/fppt/jedismock/storage/BlockingManager.java
@@ -29,6 +29,7 @@ import java.util.TreeSet;
  */
 public final class BlockingManager {
     private long nextTicket = 0L;
+    private int blockedClients = 0;
     private final Map<Slice, NavigableSet<Long>> waitersByKey = new HashMap<>();
 
     /**
@@ -40,8 +41,11 @@ public final class BlockingManager {
 
     /**
      * Record that the given ticket is blocked on each of the supplied keys.
+     * Must be paired with exactly one {@link #unregister} call per blocked
+     * client so that {@link #blockedClients()} stays accurate.
      */
     public void register(long ticket, List<Slice> keys) {
+        blockedClients++;
         for (Slice key : keys) {
             waitersByKey.computeIfAbsent(key, k -> new TreeSet<>()).add(ticket);
         }
@@ -51,6 +55,7 @@ public final class BlockingManager {
      * Remove the given ticket from all of the supplied keys.
      */
     public void unregister(long ticket, List<Slice> keys) {
+        blockedClients--;
         for (Slice key : keys) {
             NavigableSet<Long> tickets = waitersByKey.get(key);
             if (tickets != null) {
@@ -60,6 +65,16 @@ public final class BlockingManager {
                 }
             }
         }
+    }
+
+    /**
+     * @return the number of clients currently blocked on a blocking command.
+     * Mirrors the {@code blocked_clients} field of Redis {@code INFO clients},
+     * which test suites poll (via {@code wait_for_blocked_client}) to
+     * synchronize before unblocking.
+     */
+    public int blockedClients() {
+        return blockedClients;
     }
 
     /**

--- a/src/main/java/com/github/fppt/jedismock/storage/BlockingManager.java
+++ b/src/main/java/com/github/fppt/jedismock/storage/BlockingManager.java
@@ -1,0 +1,75 @@
+package com.github.fppt.jedismock.storage;
+
+import com.github.fppt.jedismock.datastructures.Slice;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableSet;
+import java.util.TreeSet;
+
+/**
+ * Tracks clients blocked on keys (BLPOP, BRPOP, BRPOPLPUSH, …) so they can be
+ * served in FIFO order, the way real Redis does.
+ * <p>
+ * Without this, a push wakes every blocked client via {@code notifyAll()} and
+ * whichever thread wins the (unfair) intrinsic-monitor race consumes the
+ * element. That breaks ordering guarantees and can hang a client forever: e.g.
+ * if a later waiter steals the only element, the older waiter re-checks, finds
+ * nothing, and blocks again with no further notification.
+ * <p>
+ * Each blocked client takes a monotonically increasing ticket and registers it
+ * against every key it waits on. A woken client may only claim an element from a
+ * key if it holds the lowest (oldest) ticket among the clients currently blocked
+ * on that key.
+ * <p>
+ * All methods must be called while holding the shared data lock
+ * ({@link OperationExecutorState#lock()}), so no internal synchronization is
+ * needed.
+ */
+public final class BlockingManager {
+    private long nextTicket = 0L;
+    private final Map<Slice, NavigableSet<Long>> waitersByKey = new HashMap<>();
+
+    /**
+     * @return a fresh ticket, ordering this waiter after all earlier ones.
+     */
+    public long nextTicket() {
+        return nextTicket++;
+    }
+
+    /**
+     * Record that the given ticket is blocked on each of the supplied keys.
+     */
+    public void register(long ticket, List<Slice> keys) {
+        for (Slice key : keys) {
+            waitersByKey.computeIfAbsent(key, k -> new TreeSet<>()).add(ticket);
+        }
+    }
+
+    /**
+     * Remove the given ticket from all of the supplied keys.
+     */
+    public void unregister(long ticket, List<Slice> keys) {
+        for (Slice key : keys) {
+            NavigableSet<Long> tickets = waitersByKey.get(key);
+            if (tickets != null) {
+                tickets.remove(ticket);
+                if (tickets.isEmpty()) {
+                    waitersByKey.remove(key);
+                }
+            }
+        }
+    }
+
+    /**
+     * @return whether the given ticket is the oldest waiter on {@code key} and
+     * may therefore claim an element that has become available. Returns
+     * {@code true} if no one is tracked for the key (defensive: never block a
+     * client that somehow isn't registered).
+     */
+    public boolean isFirst(long ticket, Slice key) {
+        NavigableSet<Long> tickets = waitersByKey.get(key);
+        return tickets == null || tickets.isEmpty() || tickets.first() == ticket;
+    }
+}

--- a/src/main/java/com/github/fppt/jedismock/storage/BlockingManager.java
+++ b/src/main/java/com/github/fppt/jedismock/storage/BlockingManager.java
@@ -21,11 +21,22 @@ import java.util.TreeSet;
  * Each blocked client takes a monotonically increasing ticket and registers it
  * against every key it waits on. A woken client may only claim an element from a
  * key if it holds the lowest (oldest) ticket among the clients currently blocked
- * on that key.
+ * on that key. A waiter is expected to register on entry and close its ticket on
+ * exit, which is most naturally done with try-with-resources:
+ * <pre>{@code
+ * try (BlockingManager.Ticket ticket = blockingManager.register(keys)) {
+ *     while (stillWaiting) {
+ *         if (available(key) && ticket.isFirst(key)) {
+ *             ...claim the element...
+ *         }
+ *         lock.wait(...);
+ *     }
+ * }
+ * }</pre>
  * <p>
- * All methods must be called while holding the shared data lock
- * ({@link OperationExecutorState#lock()}), so no internal synchronization is
- * needed.
+ * All methods (and {@link Ticket#close()}) must be called while holding the
+ * shared data lock ({@link OperationExecutorState#lock()}), so no internal
+ * synchronization is needed.
  */
 public final class BlockingManager {
     private long nextTicket = 0L;
@@ -33,38 +44,20 @@ public final class BlockingManager {
     private final Map<Slice, NavigableSet<Long>> waitersByKey = new HashMap<>();
 
     /**
-     * @return a fresh ticket, ordering this waiter after all earlier ones.
+     * Register the caller as a FIFO waiter on each of the supplied keys.
+     *
+     * @return a {@link Ticket} that must be {@link Ticket#close() closed} once
+     * the caller stops waiting (use try-with-resources). The ticket orders this
+     * waiter after all earlier ones and keeps {@link #blockedClients()}
+     * accurate.
      */
-    public long nextTicket() {
-        return nextTicket++;
-    }
-
-    /**
-     * Record that the given ticket is blocked on each of the supplied keys.
-     * Must be paired with exactly one {@link #unregister} call per blocked
-     * client so that {@link #blockedClients()} stays accurate.
-     */
-    public void register(long ticket, List<Slice> keys) {
+    public Ticket register(List<Slice> keys) {
+        long id = nextTicket++;
         blockedClients++;
         for (Slice key : keys) {
-            waitersByKey.computeIfAbsent(key, k -> new TreeSet<>()).add(ticket);
+            waitersByKey.computeIfAbsent(key, k -> new TreeSet<>()).add(id);
         }
-    }
-
-    /**
-     * Remove the given ticket from all of the supplied keys.
-     */
-    public void unregister(long ticket, List<Slice> keys) {
-        blockedClients--;
-        for (Slice key : keys) {
-            NavigableSet<Long> tickets = waitersByKey.get(key);
-            if (tickets != null) {
-                tickets.remove(ticket);
-                if (tickets.isEmpty()) {
-                    waitersByKey.remove(key);
-                }
-            }
-        }
+        return new Ticket(id, keys);
     }
 
     /**
@@ -77,14 +70,64 @@ public final class BlockingManager {
         return blockedClients;
     }
 
-    /**
-     * @return whether the given ticket is the oldest waiter on {@code key} and
-     * may therefore claim an element that has become available. Returns
-     * {@code true} if no one is tracked for the key (defensive: never block a
-     * client that somehow isn't registered).
-     */
-    public boolean isFirst(long ticket, Slice key) {
+    private boolean isFirst(long id, Slice key) {
         NavigableSet<Long> tickets = waitersByKey.get(key);
-        return tickets == null || tickets.isEmpty() || tickets.first() == ticket;
+        return tickets == null || tickets.isEmpty() || tickets.first() == id;
+    }
+
+    private void unregister(long id, List<Slice> keys) {
+        blockedClients--;
+        for (Slice key : keys) {
+            NavigableSet<Long> tickets = waitersByKey.get(key);
+            if (tickets != null) {
+                tickets.remove(id);
+                if (tickets.isEmpty()) {
+                    waitersByKey.remove(key);
+                }
+            }
+        }
+    }
+
+    /**
+     * A handle on a single blocked waiter. Holds its FIFO ticket and the keys it
+     * is registered on, and unregisters them on {@link #close()}. Obtained from
+     * {@link BlockingManager#register(List)} and intended to be used within a
+     * try-with-resources block. Not thread-safe: like the rest of
+     * {@link BlockingManager}, it must only be touched while holding the shared
+     * data lock.
+     */
+    public final class Ticket implements AutoCloseable {
+        private final long id;
+        private final List<Slice> keys;
+        private boolean closed = false;
+
+        private Ticket(long id, List<Slice> keys) {
+            this.id = id;
+            this.keys = keys;
+        }
+
+        /**
+         * @return whether this waiter is the oldest one blocked on {@code key}
+         * and may therefore claim an element that has become available. Returns
+         * {@code true} if no one is tracked for the key (defensive: never block
+         * a client that somehow isn't registered).
+         */
+        public boolean isFirst(Slice key) {
+            return BlockingManager.this.isFirst(id, key);
+        }
+
+        /**
+         * Unregister this waiter from all of its keys. Idempotent, so an
+         * explicit close followed by a try-with-resources close (or vice versa)
+         * cannot corrupt {@link #blockedClients()}.
+         */
+        @Override
+        public void close() {
+            if (closed) {
+                return;
+            }
+            closed = true;
+            unregister(id, keys);
+        }
     }
 }

--- a/src/main/java/com/github/fppt/jedismock/storage/OperationExecutorState.java
+++ b/src/main/java/com/github/fppt/jedismock/storage/OperationExecutorState.java
@@ -16,6 +16,7 @@ public class OperationExecutorState {
 
     private final RedisClient owner;
     private final Map<Integer, RedisBase> redisBases;
+    private final BlockingManager blockingManager;
     private TransactionState transactionState = TransactionState.NORMAL;
     private final List<RedisOperation> tx = new ArrayList<>();
     private final Set<Slice> watchedKeys = new HashSet<>();
@@ -24,8 +25,14 @@ public class OperationExecutorState {
     private String clientName;
 
     public OperationExecutorState(RedisClient owner, Map<Integer, RedisBase> redisBases) {
+        this(owner, redisBases, new BlockingManager());
+    }
+
+    public OperationExecutorState(RedisClient owner, Map<Integer, RedisBase> redisBases,
+                                  BlockingManager blockingManager) {
         this.owner = owner;
         this.redisBases = redisBases;
+        this.blockingManager = blockingManager;
     }
 
     public RedisBase base() {
@@ -74,6 +81,15 @@ public class OperationExecutorState {
 
     public Object lock() {
         return redisBases;
+    }
+
+    /**
+     * @return the server-wide registry used to serve blocked clients in FIFO
+     * order. Shared by every client of the same server; only mutate it while
+     * holding {@link #lock()}.
+     */
+    public BlockingManager blockingManager() {
+        return blockingManager;
     }
 
     /**

--- a/src/main/java/com/github/fppt/jedismock/storage/OperationExecutorState.java
+++ b/src/main/java/com/github/fppt/jedismock/storage/OperationExecutorState.java
@@ -76,6 +76,15 @@ public class OperationExecutorState {
         return redisBases;
     }
 
+    /**
+     * @return whether the client owning this state is still connected. Used by
+     * blocking operations to cancel themselves when their client disconnects,
+     * so they don't consume data intended for later clients.
+     */
+    public boolean isClientConnected() {
+        return owner.isConnected();
+    }
+
     public void checkWatchedKeysNotExpired() {
         for (Slice key : watchedKeys) {
             base().exists(key);

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/lists/BlockingDisconnectComparisonTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/lists/BlockingDisconnectComparisonTest.java
@@ -1,0 +1,121 @@
+package com.github.fppt.jedismock.comparisontests.lists;
+
+import com.github.fppt.jedismock.comparisontests.ComparisonBase;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.Jedis;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Comparison tests for issue #317: a blocking command must be cancelled when
+ * its client disconnects while still blocked.
+ *
+ * Real Redis frees a disconnecting client and removes it from the per-key
+ * blocked-client lists, so data pushed after the disconnect is NOT consumed by
+ * the gone client. The mock instead leaves the server-side thread parked in
+ * {@code lock.wait()} (nothing interrupts it on close, and the per-connection
+ * read loop is stuck inside the blocking command, so it cannot notice the dead
+ * socket). A later write wakes the orphan, which mutates the store and then
+ * fails to deliver the result down the dead socket.
+ *
+ * Each test asserts the correct (real-Redis) behaviour, so the "real" variant
+ * passes and the "mock" variant fails -- that contrast is the point of the
+ * investigation.
+ */
+@ExtendWith(ComparisonBase.class)
+public class BlockingDisconnectComparisonTest {
+
+    /**
+     * Drives one client to block on {@code command}, lets the server register
+     * the wait, then closes that client's socket (sending FIN/RST) to simulate
+     * a disconnect while still blocked, and waits for the server to process the
+     * disconnect. Closing the socket -- not {@code shutdownNow()} -- is what
+     * actually unblocks a thread parked in a blocking socket read, so the close
+     * happens BEFORE the post-disconnect wait. By the time this returns, a
+     * correct server has had time to cancel the block; any later write must
+     * therefore not be delivered to the gone client.
+     */
+    private void blockThenDisconnect(Jedis blockedClient, Runnable blockingCommand)
+            throws InterruptedException {
+        ExecutorService pool = Executors.newSingleThreadExecutor();
+        try {
+            pool.submit(() -> {
+                try {
+                    blockingCommand.run();
+                } catch (Exception ignored) {
+                    // The socket is closed under the blocking read -- expected.
+                }
+            });
+            Thread.sleep(500);            // let the server register the blocking wait
+            blockedClient.close();        // disconnect while still blocked
+            pool.shutdownNow();
+            pool.awaitTermination(2, TimeUnit.SECONDS);
+            Thread.sleep(700);            // let the server process the disconnect & cancel the block
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    @TestTemplate
+    public void blpopIsCancelledWhenClientDisconnects(Jedis jedis, HostAndPort hostAndPort)
+            throws InterruptedException {
+        String key = "disconnect_blpop_key";
+        jedis.del(key);
+
+        Jedis blockedClient = new Jedis(hostAndPort.getHost(), hostAndPort.getPort());
+        blockThenDisconnect(blockedClient, () -> blockedClient.blpop(0, key));
+
+        // The disconnected client must not consume this value.
+        jedis.rpush(key, "foo");
+        Thread.sleep(300); // give any orphan a chance to (wrongly) steal it
+
+        assertThat(jedis.lrange(key, 0, -1)).containsExactly("foo");
+    }
+
+    @TestTemplate
+    public void brpoplpushIsCancelledWhenClientDisconnects(Jedis jedis, HostAndPort hostAndPort)
+            throws InterruptedException {
+        String src = "disconnect_brpoplpush_src";
+        String dst = "disconnect_brpoplpush_dst";
+        jedis.del(src, dst);
+
+        Jedis blockedClient = new Jedis(hostAndPort.getHost(), hostAndPort.getPort());
+        blockThenDisconnect(blockedClient, () -> blockedClient.brpoplpush(src, dst, 0));
+
+        // The disconnected client must not move this value to dst.
+        jedis.rpush(src, "foo");
+        Thread.sleep(300);
+
+        assertThat(jedis.lrange(src, 0, -1)).containsExactly("foo");
+        assertThat(jedis.lrange(dst, 0, -1)).isEmpty();
+    }
+
+    /**
+     * The flakiness mechanism end-to-end: one "test" leaves a blocked client
+     * dangling on a key, a later "test" reuses the same key. On real Redis the
+     * first client was cancelled, so the second push behaves normally. On the
+     * mock, the orphan from the first phase steals the second phase's value.
+     */
+    @TestTemplate
+    public void orphanedBlockDoesNotLeakIntoReusedKey(Jedis jedis, HostAndPort hostAndPort)
+            throws InterruptedException {
+        String key = "reused_blocking_key";
+        jedis.del(key);
+
+        // Phase 1: a deferring client blocks and then goes away.
+        Jedis phase1Client = new Jedis(hostAndPort.getHost(), hostAndPort.getPort());
+        blockThenDisconnect(phase1Client, () -> phase1Client.blpop(0, key));
+
+        // Phase 2: an unrelated, live client uses the same key normally.
+        jedis.rpush(key, "a", "b", "c");
+        Thread.sleep(300);
+
+        assertThat(jedis.lrange(key, 0, -1)).containsExactly("a", "b", "c");
+    }
+}

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/lists/BlockingFairnessComparisonTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/lists/BlockingFairnessComparisonTest.java
@@ -3,6 +3,7 @@ package com.github.fppt.jedismock.comparisontests.lists;
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.exceptions.JedisDataException;
@@ -12,6 +13,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -61,7 +64,7 @@ public class BlockingFairnessComparisonTest {
                         done.countDown();
                     }
                 });
-                Thread.sleep(200); // ensure client1 is the older waiter
+                waitForBlockedClients(jedis, 1); // ensure client1 is the older waiter
                 pool.submit(() -> {
                     try {
                         rd2Result.set(client2.brpoplpush(src, dst2, 0));
@@ -71,7 +74,7 @@ public class BlockingFairnessComparisonTest {
                         done.countDown();
                     }
                 });
-                Thread.sleep(200); // let both register their blocks
+                waitForBlockedClients(jedis, 2); // both registered, in order
 
                 jedis.lpush(src, "foo");
 
@@ -94,5 +97,21 @@ public class BlockingFairnessComparisonTest {
                 client2.close();
             }
         }
+    }
+
+    private static final Pattern BLOCKED_CLIENTS = Pattern.compile("blocked_clients:(\\d+)");
+
+    /**
+     * Waits until {@code INFO}'s {@code blocked_clients} reaches {@code n}, the
+     * way the tcl suite's {@code wait_for_blocked_clients_count} does. This
+     * makes blocking-order deterministic for both real Redis and the mock.
+     */
+    private void waitForBlockedClients(Jedis jedis, int n) {
+        Awaitility.await().until(() -> blockedClients(jedis) == n);
+    }
+
+    private int blockedClients(Jedis jedis) {
+        Matcher matcher = BLOCKED_CLIENTS.matcher(jedis.info("clients"));
+        return matcher.find() ? Integer.parseInt(matcher.group(1)) : 0;
     }
 }

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/lists/BlockingFairnessComparisonTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/lists/BlockingFairnessComparisonTest.java
@@ -1,0 +1,98 @@
+package com.github.fppt.jedismock.comparisontests.lists;
+
+import com.github.fppt.jedismock.comparisontests.ComparisonBase;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.exceptions.JedisDataException;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Reproduces the tcl test "BRPOPLPUSH with multiple blocked clients".
+ *
+ * Several clients block on the same source key with an infinite timeout. When a
+ * value is pushed, real Redis serves the blocked clients in FIFO order: the
+ * client that blocked first gets the first crack at the element. Here the first
+ * client's destination is the wrong type, so it must fail with WRONGTYPE
+ * (leaving the element in place), and the second client must then receive it.
+ *
+ * The mock used to wake every waiter via {@code notifyAll()} and let an
+ * arbitrary thread win the monitor race. When the second client won, it stole
+ * the only element and the first client blocked forever, hanging the test.
+ * Iterating exercises the race repeatedly.
+ */
+@ExtendWith(ComparisonBase.class)
+public class BlockingFairnessComparisonTest {
+
+    @TestTemplate
+    public void brpoplpushServesMultipleBlockedClientsInOrder(Jedis jedis, HostAndPort hostAndPort)
+            throws InterruptedException {
+        for (int i = 0; i < 20; i++) {
+            String src = "blist_" + i;
+            String dst1 = "target1_" + i;
+            String dst2 = "target2_" + i;
+            jedis.del(src, dst1, dst2);
+            jedis.set(dst1, "nolist"); // first client's destination is the wrong type
+
+            Jedis client1 = new Jedis(hostAndPort.getHost(), hostAndPort.getPort());
+            Jedis client2 = new Jedis(hostAndPort.getHost(), hostAndPort.getPort());
+            ExecutorService pool = Executors.newFixedThreadPool(2);
+            AtomicReference<Throwable> rd1Error = new AtomicReference<>();
+            AtomicReference<String> rd2Result = new AtomicReference<>();
+            CountDownLatch done = new CountDownLatch(2);
+
+            try {
+                // Client 1 blocks first.
+                pool.submit(() -> {
+                    try {
+                        client1.brpoplpush(src, dst1, 0);
+                    } catch (Throwable t) {
+                        rd1Error.set(t);
+                    } finally {
+                        done.countDown();
+                    }
+                });
+                Thread.sleep(200); // ensure client1 is the older waiter
+                pool.submit(() -> {
+                    try {
+                        rd2Result.set(client2.brpoplpush(src, dst2, 0));
+                    } catch (Throwable t) {
+                        rd2Result.set("ERROR:" + t);
+                    } finally {
+                        done.countDown();
+                    }
+                });
+                Thread.sleep(200); // let both register their blocks
+
+                jedis.lpush(src, "foo");
+
+                if (!done.await(10, TimeUnit.SECONDS)) {
+                    fail("Blocked BRPOPLPUSH clients did not complete (iteration " + i
+                            + ") -- a waiter is stuck forever");
+                }
+
+                assertThat(rd1Error.get())
+                        .as("first client must fail with WRONGTYPE")
+                        .isInstanceOf(JedisDataException.class);
+                assertThat(rd1Error.get().getMessage()).startsWith("WRONGTYPE");
+                assertThat(rd2Result.get())
+                        .as("second client must receive the element")
+                        .isEqualTo("foo");
+                assertThat(jedis.lrange(dst2, 0, -1)).containsExactly("foo");
+            } finally {
+                pool.shutdownNow();
+                client1.close();
+                client2.close();
+            }
+        }
+    }
+}

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/streams/XReadTests.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/streams/XReadTests.java
@@ -13,6 +13,8 @@ import redis.clients.jedis.params.XAddParams;
 import redis.clients.jedis.params.XReadParams;
 import redis.clients.jedis.resps.StreamEntry;
 
+import org.testcontainers.shaded.org.awaitility.Awaitility;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -23,6 +25,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -30,6 +34,8 @@ import static org.assertj.core.api.InstanceOfAssertFactories.LIST;
 
 @ExtendWith(ComparisonBase.class)
 public class XReadTests {
+    private static final Pattern BLOCKED_CLIENTS = Pattern.compile("blocked_clients:(\\d+)");
+
     private ScheduledExecutorService scheduledThreadPool;
     private Jedis blockedClient;
 
@@ -186,6 +192,35 @@ public class XReadTests {
         blockingReadJob.get();
 
         assertThat(blockingReadJob.isCancelled()).isFalse();
+    }
+
+    /**
+     * Mirrors the tcl stream suite, which calls {@code wait_for_blocked_client}
+     * (polling INFO's {@code blocked_clients}) before XADD. A blocked XREAD must
+     * be reflected in that count, and must drop back to zero once served.
+     */
+    @TestTemplate
+    void blockedXreadIsReportedInInfoBlockedClients(Jedis jedis)
+            throws ExecutionException, InterruptedException {
+        assertThat(blockedClients(jedis)).isZero();
+
+        Future<?> blockingReadJob = scheduledThreadPool.submit(() ->
+                blockedClient.xread(
+                        XReadParams.xReadParams().block(0),
+                        Collections.singletonMap("st", new StreamEntryID(0, 7))
+                ));
+
+        Awaitility.await().until(() -> blockedClients(jedis) == 1);
+
+        jedis.xadd("st", XAddParams.xAddParams().id(0, 8), Collections.singletonMap("a", "b"));
+
+        blockingReadJob.get();
+        Awaitility.await().until(() -> blockedClients(jedis) == 0);
+    }
+
+    private int blockedClients(Jedis jedis) {
+        Matcher matcher = BLOCKED_CLIENTS.matcher(jedis.info("clients"));
+        return matcher.find() ? Integer.parseInt(matcher.group(1)) : 0;
     }
 
     @TestTemplate

--- a/src/test/java/com/github/fppt/jedismock/storage/BlockingManagerTest.java
+++ b/src/test/java/com/github/fppt/jedismock/storage/BlockingManagerTest.java
@@ -1,0 +1,167 @@
+package com.github.fppt.jedismock.storage;
+
+import com.github.fppt.jedismock.datastructures.Slice;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static com.github.fppt.jedismock.datastructures.Slice.create;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link BlockingManager}. They drive the manager directly (no
+ * server/lock), which is safe because all access in production already happens
+ * under a single shared lock, so single-threaded calls here faithfully mirror
+ * the real serialized access pattern.
+ */
+class BlockingManagerTest {
+
+    private final BlockingManager manager = new BlockingManager();
+
+    private static List<Slice> keys(String... names) {
+        List<Slice> result = new ArrayList<>();
+        for (String name : names) {
+            result.add(create(name));
+        }
+        return result;
+    }
+
+    @Test
+    void blockedClientsStartsAtZero() {
+        assertThat(manager.blockedClients()).isZero();
+    }
+
+    @Test
+    void registerIncrementsAndCloseDecrementsBlockedClients() {
+        BlockingManager.Ticket ticket = manager.register(keys("a"));
+        assertThat(manager.blockedClients()).isEqualTo(1);
+
+        ticket.close();
+        assertThat(manager.blockedClients()).isZero();
+    }
+
+    @Test
+    void blockedClientsCountsEveryRegisteredWaiter() {
+        BlockingManager.Ticket t1 = manager.register(keys("a"));
+        BlockingManager.Ticket t2 = manager.register(keys("a", "b"));
+        BlockingManager.Ticket t3 = manager.register(keys("c"));
+
+        assertThat(manager.blockedClients()).isEqualTo(3);
+
+        t2.close();
+        assertThat(manager.blockedClients()).isEqualTo(2);
+
+        t1.close();
+        t3.close();
+        assertThat(manager.blockedClients()).isZero();
+    }
+
+    @Test
+    void oldestWaiterIsServedFirst() {
+        Slice key = create("a");
+        BlockingManager.Ticket first = manager.register(Collections.singletonList(key));
+        BlockingManager.Ticket second = manager.register(Collections.singletonList(key));
+
+        assertThat(first.isFirst(key)).isTrue();
+        assertThat(second.isFirst(key)).isFalse();
+    }
+
+    @Test
+    void closingOldestPromotesNextInLine() {
+        Slice key = create("a");
+        BlockingManager.Ticket first = manager.register(Collections.singletonList(key));
+        BlockingManager.Ticket second = manager.register(Collections.singletonList(key));
+        BlockingManager.Ticket third = manager.register(Collections.singletonList(key));
+
+        first.close();
+        assertThat(second.isFirst(key)).isTrue();
+        assertThat(third.isFirst(key)).isFalse();
+
+        second.close();
+        assertThat(third.isFirst(key)).isTrue();
+    }
+
+    @Test
+    void orderingIsTrackedPerKey() {
+        Slice a = create("a");
+        Slice b = create("b");
+        //first blocks on a only; second blocks on a and b.
+        BlockingManager.Ticket first = manager.register(Collections.singletonList(a));
+        BlockingManager.Ticket second = manager.register(Arrays.asList(a, b));
+
+        //On a, first is older. On b, second is the only (hence oldest) waiter.
+        assertThat(first.isFirst(a)).isTrue();
+        assertThat(second.isFirst(a)).isFalse();
+        assertThat(second.isFirst(b)).isTrue();
+
+        //Once first leaves a, second leads on a too.
+        first.close();
+        assertThat(second.isFirst(a)).isTrue();
+    }
+
+    @Test
+    void unregisteredKeyDefaultsToFirst() {
+        //Defensive contract: a waiter is never blocked on a key it isn't
+        //tracked for (e.g. it registered on "a" but probes "other").
+        Slice tracked = create("a");
+        Slice untracked = create("other");
+        BlockingManager.Ticket ticket = manager.register(Collections.singletonList(tracked));
+
+        assertThat(ticket.isFirst(untracked)).isTrue();
+    }
+
+    @Test
+    void afterAllWaitersLeaveKeyAnyTicketIsFirstAgain() {
+        Slice key = create("a");
+        BlockingManager.Ticket first = manager.register(Collections.singletonList(key));
+        BlockingManager.Ticket second = manager.register(Collections.singletonList(key));
+
+        first.close();
+        second.close();
+
+        //No one is tracked for the key anymore: a brand-new waiter leads.
+        BlockingManager.Ticket third = manager.register(Collections.singletonList(key));
+        assertThat(third.isFirst(key)).isTrue();
+        third.close();
+    }
+
+    @Test
+    void closeIsIdempotent() {
+        BlockingManager.Ticket ticket = manager.register(keys("a"));
+        assertThat(manager.blockedClients()).isEqualTo(1);
+
+        ticket.close();
+        ticket.close();
+        ticket.close();
+
+        //Count must not go negative from repeated closes.
+        assertThat(manager.blockedClients()).isZero();
+    }
+
+    @Test
+    void closeDoesNotAffectOtherWaitersOnSharedKey() {
+        Slice key = create("a");
+        BlockingManager.Ticket first = manager.register(Collections.singletonList(key));
+        BlockingManager.Ticket second = manager.register(Collections.singletonList(key));
+
+        //Closing the same ticket twice must not corrupt the other waiter's standing.
+        first.close();
+        first.close();
+
+        assertThat(manager.blockedClients()).isEqualTo(1);
+        assertThat(second.isFirst(key)).isTrue();
+    }
+
+    @Test
+    void worksWithTryWithResources() {
+        Slice key = create("a");
+        try (BlockingManager.Ticket ticket = manager.register(Collections.singletonList(key))) {
+            assertThat(manager.blockedClients()).isEqualTo(1);
+            assertThat(ticket.isFirst(key)).isTrue();
+        }
+        assertThat(manager.blockedClients()).isZero();
+    }
+}


### PR DESCRIPTION
Fixes #770. Also addresses the FIFO-ordering aspect of #317.

## Summary

Blocking commands (`BLPOP`/`BRPOP`/`BRPOPLPUSH` and blocking `XREAD`) had two problems:

1. **They were never cancelled when their client disconnected while blocked** (#770). The server-side thread stayed parked in `lock.wait()`; a later write to the same key would wake the orphan, which mutated the store (popped/moved the element) and only then discovered its socket was dead — silently losing the element, or moving it on behalf of a client that no longer existed. Because the TCL suite heavily reuses key names, an orphaned block from one test would steal a push in a later one.

2. **Among several clients blocked on the same key, an arbitrary waiter was served** instead of the oldest. `notifyAll()` let whichever thread won the intrinsic-monitor race claim the element, breaking real Redis's FIFO ordering and occasionally leaving an older waiter blocked forever.

## Changes

**Disconnect cancellation**
- `RedisClient.isConnected()` — a best-effort liveness probe safe to call while holding the data lock. It sends a single TCP urgent (out-of-band) byte: a live peer silently discards it, a gone peer makes the write fail.
- Blocking loops now poll liveness (waking at most every `POLL_MILLIS = 100ms`, even on an infinite `timeout 0` block) and bail out with `Response.SKIP` — consuming nothing and replying nothing — once the client is gone. The disconnect state is captured by the loop so a transient probe failure at delivery time can't drop a legitimate reply.

**FIFO fairness (`BlockingManager`)**
- New server-wide `BlockingManager` issues a monotonic ticket per blocked waiter, registered against every key it waits on. A woken waiter may only claim an element from a key if it holds the oldest ticket for that key; on exit it hands the turn to the next in line. Used via try-with-resources (`BlockingManager.Ticket`).
- Wired through `RedisServer` → `OperationExecutorState` (shared per server) and applied in `AbstractBPop` and `BRPopLPush`. Blocking `XREAD` registers too (for the `blocked_clients` count) but skips the `isFirst` check, since a stream entry satisfies every blocked reader.

**`INFO blocked_clients`**
- `INFO` now reports `blocked_clients` (from `BlockingManager`), so test suites' `wait_for_blocked_clients_count` can synchronize before unblocking.

## Tests
- `BlockingDisconnectComparisonTest` — BLPOP / BRPOPLPUSH cancelled on disconnect, and an orphaned block doesn't leak into a reused key (mock vs. real Redis).
- `BlockingFairnessComparisonTest` — multiple clients blocked on the same key are served in order.
- `BlockingManagerTest` — unit coverage of ticket ordering, per-key tracking, `blocked_clients` accounting, and idempotent close.
- `XReadTests` — blocked XREAD is reflected in `INFO blocked_clients`.
- Re-enabled the previously-commented `BRPOPLPUSH with multiple blocked clients` TCL test (using `wait_for_blocked_clients_count`); documented why the `Linked BRPOPLPUSH` cascade test stays disabled.