### PR TITLE
Pass unit/multi.tcl: Lua script timeouts (SCRIPT KILL / BUSY), thin CONFIG, and WATCH-on-expiry fix

### DIFF
--- a/.github/workflows/native-tests.yml
+++ b/.github/workflows/native-tests.yml
@@ -93,3 +93,8 @@ jobs:
         if: always()
         run: ./testnative unit/expire
         working-directory: native_tests
+
+      - name: multi
+        if: always()
+        run: ./testnative unit/multi
+        working-directory: native_tests

--- a/README.md
+++ b/README.md
@@ -175,6 +175,24 @@ A long-running (or even infinite) script does not lock up the mock. Once a scrip
 
 Feel free to report an issue if you have any problems with Lua scripting in Jedis-Mock.
 
+## `CONFIG GET` / `CONFIG SET`
+
+`CONFIG` is supported as a deliberately *thin* mock. Fully modelling Redis configuration is a non-goal; the point is twofold:
+
+* Real-world code issues `CONFIG` even when you never call it directly. Most notably, Spring Data Redis / Spring Session send `CONFIG SET notify-keyspace-events` automatically when a key-expiration listener is registered (via `ConfigureNotifyKeyspaceEventsAction`); drivers such as Lettuce, Jedis and Redisson also expose `CONFIG GET`/`SET` in their API. None of this should fail with an "unsupported operation" error ([#40](https://github.com/fppt/jedis-mock/issues/40)).
+* A value written with `CONFIG SET` should read back with `CONFIG GET`.
+
+So **arbitrary parameters are accepted and round-trip** through a separate namespace without affecting the mock in any way (an unset parameter reads back as an empty string, matching real Redis). For example, setting `maxmemory-policy` stores the value and returns it on `GET`, but does not actually change eviction behaviour.
+
+Only **two parameters are "behavioural"** — they are actually honoured by the mock:
+
+| Parameter | Effect | Default |
+| --- | --- | --- |
+| `lua-time-limit` (alias `busy-reply-threshold`) | how long a Lua script may run before other clients get `-BUSY` (see [Script timeouts](#script-timeouts-busy-and-script-kill)) | `5000` (ms); `0` disables |
+| `proto-max-bulk-len` | largest string a command may build, enforced by `SETRANGE`/`APPEND` (`-ERR string exceeds maximum allowed size`) | `536870912` (512 MB) |
+
+`proto-max-bulk-len` is capped at `Integer.MAX_VALUE`, since the mock stores strings as `byte[]` and cannot honour a larger limit. Glob-style patterns in `CONFIG GET` are not supported; each argument is treated as a literal parameter name.
+
 ## <a name="clockinjection">Clock injection</a>
 
 [`java.time.Clock`](https://docs.oracle.com/javase/8/docs/api/java/time/Clock.html) injection is supported via `setClock` method on `RedisServer`. The injected clock is used for calculation and verification of the keys expiration time. Thus, it's possible to "freeze" or "skip" time for better testing of keys expiration. `setClock` is a thread-safe method which can be called as needed from any place of the code.

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ try (Jedis jedis = new Jedis(server.getHost(),
 
 ## Lua scripting support
 
-JedisMock supports Lua scripting (`EVAL`, `EVALSHA`, `SCRIPT LOAD/EXISTS/FLUSH` commands) via [luaj](https://github.com/luaj/luaj).  
+JedisMock supports Lua scripting (`EVAL`, `EVALSHA`, `SCRIPT LOAD/EXISTS/FLUSH/KILL` commands) via [luaj](https://github.com/luaj/luaj).  
 
 ```java
 String script =
@@ -168,6 +168,10 @@ jedis.lrange("mylist", 0, -1));
 ```
 
 :warning: Lua language capabilities are restricted to what is provided by current LuaJ version. Methods provided by `redis` global object are currently restricted to what was available in Redis version 2.6.0 (see [redis.lua](src/main/resources/redis.lua)).
+
+### Script timeouts: `BUSY` and `SCRIPT KILL`
+
+A long-running (or even infinite) script does not lock up the mock. Once a script has been running longer than `lua-time-limit` milliseconds, other connections get the same `-BUSY Redis is busy running a script. You can only call SCRIPT KILL or SHUTDOWN NOSAVE.` reply as real Redis, and `SCRIPT KILL` aborts the running script (replying `-NOTBUSY` when nothing is running). The threshold defaults to 5000 ms and can be changed with `CONFIG SET lua-time-limit <ms>` (its alias `busy-reply-threshold` is also accepted); `0` disables it. This lets you test client behaviour around busy scripts and transactions interrupted by a script timeout.
 
 Feel free to report an issue if you have any problems with Lua scripting in Jedis-Mock.
 

--- a/native_tests/linux/tests/unit/multi.tcl
+++ b/native_tests/linux/tests/unit/multi.tcl
@@ -1,0 +1,940 @@
+proc wait_for_dbsize {size} {
+    set r2 [redis_client]
+    wait_for_condition 50 100 {
+        [$r2 dbsize] == $size
+    } else {
+        fail "Target dbsize not reached"
+    }
+    $r2 close
+}
+
+start_server {tags {"multi"}} {
+    test {MULTI / EXEC basics} {
+        r del mylist
+        r rpush mylist a
+        r rpush mylist b
+        r rpush mylist c
+        r multi
+        set v1 [r lrange mylist 0 -1]
+        set v2 [r ping]
+        set v3 [r exec]
+        list $v1 $v2 $v3
+    } {QUEUED QUEUED {{a b c} PONG}}
+
+    test {DISCARD} {
+        r del mylist
+        r rpush mylist a
+        r rpush mylist b
+        r rpush mylist c
+        r multi
+        set v1 [r del mylist]
+        set v2 [r discard]
+        set v3 [r lrange mylist 0 -1]
+        list $v1 $v2 $v3
+    } {QUEUED OK {a b c}}
+
+    test {Nested MULTI are not allowed} {
+        set err {}
+        r multi
+        catch {[r multi]} err
+        r exec
+        set _ $err
+    } {*ERR MULTI*}
+
+    test {MULTI where commands alter argc/argv} {
+        r sadd myset a
+        r multi
+        r spop myset
+        list [r exec] [r exists myset]
+    } {a 0}
+
+    test {WATCH inside MULTI is not allowed} {
+        set err {}
+        r multi
+        catch {[r watch x]} err
+        r exec
+        set _ $err
+    } {*ERR WATCH*}
+
+    test {EXEC fails if there are errors while queueing commands #1} {
+        r del foo1{t} foo2{t}
+        r multi
+        r set foo1{t} bar1
+        catch {r non-existing-command}
+        r set foo2{t} bar2
+        catch {r exec} e
+        assert_match {EXECABORT*} $e
+        list [r exists foo1{t}] [r exists foo2{t}]
+    } {0 0}
+
+    #test {EXEC fails if there are errors while queueing commands #2} {
+    #    set rd [redis_deferring_client]
+    #    r del foo1{t} foo2{t}
+    #    r multi
+    #    r set foo1{t} bar1
+    #    $rd config set maxmemory 1
+    #    assert  {[$rd read] eq {OK}}
+    #    catch {r lpush mylist{t} myvalue}
+    #    $rd config set maxmemory 0
+    #    assert  {[$rd read] eq {OK}}
+    #    r set foo2{t} bar2
+    #    catch {r exec} e
+    #    assert_match {EXECABORT*} $e
+    #    $rd close
+    #    list [r exists foo1{t}] [r exists foo2{t}]
+    #} {0 0} {needs:config-maxmemory}
+
+    test {If EXEC aborts, the client MULTI state is cleared} {
+        r del foo1{t} foo2{t}
+        r multi
+        r set foo1{t} bar1
+        catch {r non-existing-command}
+        r set foo2{t} bar2
+        catch {r exec} e
+        assert_match {EXECABORT*} $e
+        r ping
+    } {PONG}
+
+    test {EXEC works on WATCHed key not modified} {
+        r watch x{t} y{t} z{t}
+        r watch k{t}
+        r multi
+        r ping
+        r exec
+    } {PONG}
+
+    test {EXEC fail on WATCHed key modified (1 key of 1 watched)} {
+        r set x 30
+        r watch x
+        r set x 40
+        r multi
+        r ping
+        r exec
+    } {}
+
+    test {EXEC fail on WATCHed key modified (1 key of 5 watched)} {
+        r set x{t} 30
+        r watch a{t} b{t} x{t} k{t} z{t}
+        r set x{t} 40
+        r multi
+        r ping
+        r exec
+    } {}
+
+    #test {EXEC fail on WATCHed key modified by SORT with STORE even if the result is empty} {
+    #    r flushdb
+    #    r lpush foo bar
+    #    r watch foo
+    #    r sort emptylist store foo
+    #    r multi
+    #    r ping
+    #    r exec
+    #} {} {cluster:skip}
+
+    #test {EXEC fail on lazy expired WATCHed key} {
+    #    r del key
+    #    r debug set-active-expire 0
+	#
+    #    for {set j 0} {$j < 10} {incr j} {
+    #        r set key 1 px 100
+    #        r watch key
+    #        after 101
+    #        r multi
+    #        r incr key
+	#
+    #        set res [r exec]
+    #        if {$res eq {}} break
+    #    }
+    #    if {$::verbose} { puts "EXEC fail on lazy expired WATCHed key attempts: $j" }
+	#
+    #    r debug set-active-expire 1
+    #    set _ $res
+    #} {} {needs:debug}
+	#
+    #test {WATCH stale keys should not fail EXEC} {
+    #    r del x
+    #    r debug set-active-expire 0
+    #    r set x foo px 1
+    #    after 2
+    #    r watch x
+    #    r multi
+    #    r ping
+    #    assert_equal {PONG} [r exec]
+    #    r debug set-active-expire 1
+    #} {OK} {needs:debug}
+	#
+    #test {Delete WATCHed stale keys should not fail EXEC} {
+    #    r del x
+    #    r debug set-active-expire 0
+    #    r set x foo px 1
+    #    after 2
+    #    r watch x
+    #    # EXISTS triggers lazy expiry/deletion
+    #    assert_equal 0 [r exists x]
+    #    r multi
+    #    r ping
+    #    assert_equal {PONG} [r exec]
+    #    r debug set-active-expire 1
+    #} {OK} {needs:debug}
+	#
+    #test {FLUSHDB while watching stale keys should not fail EXEC} {
+    #    r del x
+    #    r debug set-active-expire 0
+    #    r set x foo px 1
+    #    after 2
+    #    r watch x
+    #    r flushdb
+    #    r multi
+    #    r ping
+    #    assert_equal {PONG} [r exec]
+    #    r debug set-active-expire 1
+    #} {OK} {needs:debug}
+
+    test {After successful EXEC key is no longer watched} {
+        r set x 30
+        r watch x
+        r multi
+        r ping
+        r exec
+        r set x 40
+        r multi
+        r ping
+        r exec
+    } {PONG}
+
+    test {After failed EXEC key is no longer watched} {
+        r set x 30
+        r watch x
+        r set x 40
+        r multi
+        r ping
+        r exec
+        r set x 40
+        r multi
+        r ping
+        r exec
+    } {PONG}
+
+    test {It is possible to UNWATCH} {
+        r set x 30
+        r watch x
+        r set x 40
+        r unwatch
+        r multi
+        r ping
+        r exec
+    } {PONG}
+
+    test {UNWATCH when there is nothing watched works as expected} {
+        r unwatch
+    } {OK}
+
+    test {FLUSHALL is able to touch the watched keys} {
+        r set x 30
+        r watch x
+        r flushall
+        r multi
+        r ping
+        r exec
+    } {}
+
+    test {FLUSHALL does not touch non affected keys} {
+        r del x
+        r watch x
+        r flushall
+        r multi
+        r ping
+        r exec
+    } {PONG}
+
+    test {FLUSHDB is able to touch the watched keys} {
+        r set x 30
+        r watch x
+        r flushdb
+        r multi
+        r ping
+        r exec
+    } {}
+
+    test {FLUSHDB does not touch non affected keys} {
+        r del x
+        r watch x
+        r flushdb
+        r multi
+        r ping
+        r exec
+    } {PONG}
+
+    #test {SWAPDB is able to touch the watched keys that exist} {
+    #    r flushall
+    #    r select 0
+    #    r set x 30
+    #    r watch x ;# make sure x (set to 30) doesn't change (SWAPDB will "delete" it)
+    #    r swapdb 0 1
+    #    r multi
+    #    r ping
+    #    r exec
+    #} {} {singledb:skip}
+	#
+    #test {SWAPDB is able to touch the watched keys that do not exist} {
+    #    r flushall
+    #    r select 1
+    #    r set x 30
+    #    r select 0
+    #    r watch x ;# make sure the key x (currently missing) doesn't change (SWAPDB will create it)
+    #    r swapdb 0 1
+    #    r multi
+    #    r ping
+    #    r exec
+    #} {} {singledb:skip}
+	#
+    #test {SWAPDB does not touch watched stale keys} {
+    #    r flushall
+    #    r select 1
+    #    r debug set-active-expire 0
+    #    r set x foo px 1
+    #    after 2
+    #    r watch x
+    #    r swapdb 0 1 ; # expired key replaced with no key => no change
+    #    r multi
+    #    r ping
+    #    assert_equal {PONG} [r exec]
+    #    r debug set-active-expire 1
+    #} {OK} {singledb:skip needs:debug}
+	#
+    #test {SWAPDB does not touch non-existing key replaced with stale key} {
+    #    r flushall
+    #    r select 0
+    #    r debug set-active-expire 0
+    #    r set x foo px 1
+    #    after 2
+    #    r select 1
+    #    r watch x
+    #    r swapdb 0 1 ; # no key replaced with expired key => no change
+    #    r multi
+    #    r ping
+    #    assert_equal {PONG} [r exec]
+    #    r debug set-active-expire 1
+    #} {OK} {singledb:skip needs:debug}
+	#
+    #test {SWAPDB does not touch stale key replaced with another stale key} {
+    #    r flushall
+    #    r debug set-active-expire 0
+    #    r select 1
+    #    r set x foo px 1
+    #    r select 0
+    #    r set x bar px 1
+    #    after 2
+    #    r select 1
+    #    r watch x
+    #    r swapdb 0 1 ; # no key replaced with expired key => no change
+    #    r multi
+    #    r ping
+    #    assert_equal {PONG} [r exec]
+    #    r debug set-active-expire 1
+    #} {OK} {singledb:skip needs:debug}
+
+    test {WATCH is able to remember the DB a key belongs to} {
+        r select 5
+        r set x 30
+        r watch x
+        r select 1
+        r set x 10
+        r select 5
+        r multi
+        r ping
+        set res [r exec]
+        # Restore original DB
+        r select 9
+        set res
+    } {PONG} {singledb:skip}
+
+    test {WATCH will consider touched keys target of EXPIRE} {
+        r del x
+        r set x foo
+        r watch x
+        r expire x 10
+        r multi
+        r ping
+        r exec
+    } {}
+
+    test {WATCH will consider touched expired keys} {
+        r flushall
+        r del x
+        r set x foo
+        r expire x 1
+        r watch x
+
+        # Wait for the keys to expire.
+        wait_for_dbsize 0
+
+        r multi
+        r ping
+        r exec
+    } {}
+
+    test {DISCARD should clear the WATCH dirty flag on the client} {
+        r watch x
+        r set x 10
+        r multi
+        r discard
+        r multi
+        r incr x
+        r exec
+    } {11}
+
+    test {DISCARD should UNWATCH all the keys} {
+        r watch x
+        r set x 10
+        r multi
+        r discard
+        r set x 10
+        r multi
+        r incr x
+        r exec
+    } {11}
+
+    #test {MULTI / EXEC is not propagated (single write command)} {
+    #    set repl [attach_to_replication_stream]
+    #    r multi
+    #    r set foo bar
+    #    r exec
+    #    r set foo2 bar
+    #    assert_replication_stream $repl {
+    #        {select *}
+    #        {set foo bar}
+    #        {set foo2 bar}
+    #    }
+    #    close_replication_stream $repl
+    #} {} {needs:repl}
+	#
+    #test {MULTI / EXEC is propagated correctly (multiple commands)} {
+    #    set repl [attach_to_replication_stream]
+    #    r multi
+    #    r set foo{t} bar
+    #    r get foo{t}
+    #    r set foo2{t} bar2
+    #    r get foo2{t}
+    #    r set foo3{t} bar3
+    #    r get foo3{t}
+    #    r exec
+	#
+    #    assert_replication_stream $repl {
+    #        {multi}
+    #        {select *}
+    #        {set foo{t} bar}
+    #        {set foo2{t} bar2}
+    #        {set foo3{t} bar3}
+    #        {exec}
+    #    }
+    #    close_replication_stream $repl
+    #} {} {needs:repl}
+	#
+    #test {MULTI / EXEC is propagated correctly (multiple commands with SELECT)} {
+    #    set repl [attach_to_replication_stream]
+    #    r multi
+    #    r select 1
+    #    r set foo{t} bar
+    #    r get foo{t}
+    #    r select 2
+    #    r set foo2{t} bar2
+    #    r get foo2{t}
+    #    r select 3
+    #    r set foo3{t} bar3
+    #    r get foo3{t}
+    #    r exec
+	#
+    #    assert_replication_stream $repl {
+    #        {multi}
+    #        {select *}
+    #        {set foo{t} bar}
+    #        {select *}
+    #        {set foo2{t} bar2}
+    #        {select *}
+    #        {set foo3{t} bar3}
+    #        {exec}
+    #    }
+    #    close_replication_stream $repl
+    #} {} {needs:repl singledb:skip}
+	#
+    #test {MULTI / EXEC is propagated correctly (empty transaction)} {
+    #    set repl [attach_to_replication_stream]
+    #    r multi
+    #    r exec
+    #    r set foo bar
+    #    assert_replication_stream $repl {
+    #        {select *}
+    #        {set foo bar}
+    #    }
+    #    close_replication_stream $repl
+    #} {} {needs:repl}
+	#
+    #test {MULTI / EXEC is propagated correctly (read-only commands)} {
+    #    r set foo value1
+    #    set repl [attach_to_replication_stream]
+    #    r multi
+    #    r get foo
+    #    r exec
+    #    r set foo value2
+    #    assert_replication_stream $repl {
+    #        {select *}
+    #        {set foo value2}
+    #    }
+    #    close_replication_stream $repl
+    #} {} {needs:repl}
+	#
+    #test {MULTI / EXEC is propagated correctly (write command, no effect)} {
+    #    r del bar
+    #    r del foo
+    #    set repl [attach_to_replication_stream]
+    #    r multi
+    #    r del foo
+    #    r exec
+	#
+    #    # add another command so that when we see it we know multi-exec wasn't
+    #    # propagated
+    #    r incr foo
+	#
+    #    assert_replication_stream $repl {
+    #        {select *}
+    #        {incr foo}
+    #    }
+    #    close_replication_stream $repl
+    #} {} {needs:repl}
+	#
+    #test {MULTI / EXEC with REPLICAOF} {
+    #    # This test verifies that if we demote a master to replica inside a transaction, the
+    #    # entire transaction is not propagated to the already-connected replica
+    #    set repl [attach_to_replication_stream]
+    #    r set foo bar
+    #    r multi
+    #    r set foo2 bar
+    #    r replicaof localhost 9999
+    #    r set foo3 bar
+    #    r exec
+    #    catch {r set foo4 bar} e
+    #    assert_match {READONLY*} $e
+    #    assert_replication_stream $repl {
+    #        {select *}
+    #        {set foo bar}
+    #    }
+    #    r replicaof no one
+    #} {OK} {needs:repl cluster:skip}
+	#
+    #test {DISCARD should not fail during OOM} {
+    #    set rd [redis_deferring_client]
+    #    $rd config set maxmemory 1
+    #    assert  {[$rd read] eq {OK}}
+    #    r multi
+    #    catch {r set x 1} e
+    #    assert_match {OOM*} $e
+    #    r discard
+    #    $rd config set maxmemory 0
+    #    assert  {[$rd read] eq {OK}}
+    #    $rd close
+    #    r ping
+    #} {PONG} {needs:config-maxmemory}
+
+    test {MULTI and script timeout} {
+        # check that if MULTI arrives during timeout, it is either refused, or
+        # allowed to pass, and we don't end up executing half of the transaction
+        set rd1 [redis_deferring_client]
+        set r2 [redis_client]
+        r config set lua-time-limit 10
+        r set xx 1
+        $rd1 eval {while true do end} 0
+        after 200
+        catch { $r2 multi; } e
+        catch { $r2 incr xx; } e
+        r script kill
+        after 200 ; # Give some time to Lua to call the hook again...
+        catch { $r2 incr xx; } e
+        catch { $r2 exec; } e
+        assert_match {EXECABORT*previous errors*} $e
+        set xx [r get xx]
+        # make sure that either the whole transcation passed or none of it (we actually expect none)
+        assert { $xx == 1 || $xx == 3}
+        # check that the connection is no longer in multi state
+        set pong [$r2 ping asdf]
+        assert_equal $pong "asdf"
+        $rd1 close; $r2 close
+    }
+
+    test {EXEC and script timeout} {
+        # check that if EXEC arrives during timeout, we don't end up executing
+        # half of the transaction, and also that we exit the multi state
+        set rd1 [redis_deferring_client]
+        set r2 [redis_client]
+        r config set lua-time-limit 10
+        r set xx 1
+        catch { $r2 multi; } e
+        catch { $r2 incr xx; } e
+        $rd1 eval {while true do end} 0
+        after 200
+        catch { $r2 incr xx; } e
+        catch { $r2 exec; } e
+        assert_match {EXECABORT*BUSY*} $e
+        r script kill
+        after 200 ; # Give some time to Lua to call the hook again...
+        set xx [r get xx]
+        # make sure that either the whole transcation passed or none of it (we actually expect none)
+        assert { $xx == 1 || $xx == 3}
+        # check that the connection is no longer in multi state
+        set pong [$r2 ping asdf]
+        assert_equal $pong "asdf"
+        $rd1 close; $r2 close
+    }
+
+    test {MULTI-EXEC body and script timeout} {
+        # check that we don't run an incomplete transaction due to some commands
+        # arriving during busy script
+        set rd1 [redis_deferring_client]
+        set r2 [redis_client]
+        r config set lua-time-limit 10
+        r set xx 1
+        catch { $r2 multi; } e
+        catch { $r2 incr xx; } e
+        $rd1 eval {while true do end} 0
+        after 200
+        catch { $r2 incr xx; } e
+        r script kill
+        after 200 ; # Give some time to Lua to call the hook again...
+        catch { $r2 exec; } e
+        assert_match {EXECABORT*previous errors*} $e
+        set xx [r get xx]
+        # make sure that either the whole transcation passed or none of it (we actually expect none)
+        assert { $xx == 1 || $xx == 3}
+        # check that the connection is no longer in multi state
+        set pong [$r2 ping asdf]
+        assert_equal $pong "asdf"
+        $rd1 close; $r2 close
+    }
+
+    test {just EXEC and script timeout} {
+        # check that if EXEC arrives during timeout, we don't end up executing
+        # actual commands during busy script, and also that we exit the multi state
+        set rd1 [redis_deferring_client]
+        set r2 [redis_client]
+        r config set lua-time-limit 10
+        r set xx 1
+        catch { $r2 multi; } e
+        catch { $r2 incr xx; } e
+        $rd1 eval {while true do end} 0
+        after 200
+        catch { $r2 exec; } e
+        assert_match {EXECABORT*BUSY*} $e
+        r script kill
+        after 200 ; # Give some time to Lua to call the hook again...
+        set xx [r get xx]
+        # make we didn't execute the transaction
+        assert { $xx == 1}
+        # check that the connection is no longer in multi state
+        set pong [$r2 ping asdf]
+        assert_equal $pong "asdf"
+        $rd1 close; $r2 close
+    }
+
+    # --- Disabled (out of scope for jedis-mock): these require replica state /
+    # min-replicas-to-write, REPLICAOF, replication-stream propagation, OOM
+    # (maxmemory) enforcement, or AOF/BGREWRITEAOF — none of which are modelled. ---
+    if 0 {
+    test {exec with write commands and state change} {
+        # check that exec that contains write commands fails if server state changed since they were queued
+        set r1 [redis_client]
+        r set xx 1
+        r multi
+        r incr xx
+        $r1 config set min-replicas-to-write 2
+        catch {r exec} e
+        assert_match {*EXECABORT*NOREPLICAS*} $e
+        set xx [r get xx]
+        # make sure that the INCR wasn't executed
+        assert { $xx == 1}
+        $r1 config set min-replicas-to-write 0
+        $r1 close
+    } {0} {needs:repl}
+
+    test {exec with read commands and stale replica state change} {
+        # check that exec that contains read commands fails if server state changed since they were queued
+        r config set replica-serve-stale-data no
+        set r1 [redis_client]
+        r set xx 1
+
+        # check that GET and PING are disallowed on stale replica, even if the replica becomes stale only after queuing.
+        r multi
+        r get xx
+        $r1 replicaof localhsot 0
+        catch {r exec} e
+        assert_match {*EXECABORT*MASTERDOWN*} $e
+
+        # reset
+        $r1 replicaof no one
+
+        r multi
+        r ping
+        $r1 replicaof localhsot 0
+        catch {r exec} e
+        assert_match {*EXECABORT*MASTERDOWN*} $e
+
+        # check that when replica is not stale, GET is allowed
+        # while we're at it, let's check that multi is allowed on stale replica too
+        r multi
+        $r1 replicaof no one
+        r get xx
+        set xx [r exec]
+        # make sure that the INCR was executed
+        assert { $xx == 1 }
+        $r1 close
+    } {0} {needs:repl cluster:skip}
+    }
+
+    test {EXEC with only read commands should not be rejected when OOM} {
+        set r2 [redis_client]
+
+        r set x value
+        r multi
+        r get x
+        r ping
+
+        # enforcing OOM
+        $r2 config set maxmemory 1
+
+        # finish the multi transaction with exec
+        assert { [r exec] == {value PONG} }
+
+        # releasing OOM
+        $r2 config set maxmemory 0
+        $r2 close
+    } {0} {needs:config-maxmemory}
+
+    # --- Disabled (out of scope): OOM enforcement, and blocking commands
+    # (BLMOVE/XREADGROUP) that jedis-mock does not implement. ---
+    if 0 {
+    test {EXEC with at least one use-memory command should fail} {
+        set r2 [redis_client]
+
+        r multi
+        r set x 1
+        r get x
+
+        # enforcing OOM
+        $r2 config set maxmemory 1
+
+        # finish the multi transaction with exec
+        catch {r exec} e
+        assert_match {EXECABORT*OOM*} $e
+
+        # releasing OOM
+        $r2 config set maxmemory 0
+        $r2 close
+    } {0} {needs:config-maxmemory}
+
+    test {Blocking commands ignores the timeout} {
+        r xgroup create s{t} g $ MKSTREAM
+
+        set m [r multi]
+        r blpop empty_list{t} 0
+        r brpop empty_list{t} 0
+        r brpoplpush empty_list1{t} empty_list2{t} 0
+        r blmove empty_list1{t} empty_list2{t} LEFT LEFT 0
+        r bzpopmin empty_zset{t} 0
+        r bzpopmax empty_zset{t} 0
+        r xread BLOCK 0 STREAMS s{t} $
+        r xreadgroup group g c BLOCK 0 STREAMS s{t} >
+        set res [r exec]
+
+        list $m $res
+    } {OK {{} {} {} {} {} {} {} {}}}
+    }
+
+    # --- Disabled (out of scope): replication-stream propagation
+    # (attach_to_replication_stream), REPLICAOF, SAVE/SHUTDOWN/BGREWRITEAOF,
+    # AOF, and CONFIG-error reply semantics — none modelled by jedis-mock. ---
+    if 0 {
+    test {MULTI propagation of PUBLISH} {
+        set repl [attach_to_replication_stream]
+
+        r multi
+        r publish bla bla
+        r exec
+
+        assert_replication_stream $repl {
+            {select *}
+            {publish bla bla}
+        }
+        close_replication_stream $repl
+    } {} {needs:repl cluster:skip}
+
+    test {MULTI propagation of SCRIPT LOAD} {
+        set repl [attach_to_replication_stream]
+
+        # make sure that SCRIPT LOAD inside MULTI isn't propagated
+        r multi
+        r script load {redis.call('set', KEYS[1], 'foo')}
+        r set foo bar
+        set res [r exec]
+        set sha [lindex $res 0]
+
+        assert_replication_stream $repl {
+            {select *}
+            {set foo bar}
+        }
+        close_replication_stream $repl
+    } {} {needs:repl}
+
+    test {MULTI propagation of EVAL} {
+        set repl [attach_to_replication_stream]
+
+        # make sure that EVAL inside MULTI is propagated in a transaction in effects
+        r multi
+        r eval {redis.call('set', KEYS[1], 'bar')} 1 bar
+        r exec
+
+        assert_replication_stream $repl {
+            {select *}
+            {set bar bar}
+        }
+        close_replication_stream $repl
+    } {} {needs:repl}
+
+    test {MULTI propagation of SCRIPT FLUSH} {
+        set repl [attach_to_replication_stream]
+
+        # make sure that SCRIPT FLUSH isn't propagated
+        r multi
+        r script flush
+        r set foo bar
+        r exec
+
+        assert_replication_stream $repl {
+            {select *}
+            {set foo bar}
+        }
+        close_replication_stream $repl
+    } {} {needs:repl}
+
+    tags {"stream"} {
+        test {MULTI propagation of XREADGROUP} {
+            set repl [attach_to_replication_stream]
+
+            r XADD mystream * foo bar
+            r XADD mystream * foo2 bar2
+            r XADD mystream * foo3 bar3
+            r XGROUP CREATE mystream mygroup 0
+
+            # make sure the XCALIM (propagated by XREADGROUP) is indeed inside MULTI/EXEC
+            r multi
+            r XREADGROUP GROUP mygroup consumer1 COUNT 2 STREAMS mystream ">"
+            r XREADGROUP GROUP mygroup consumer1 STREAMS mystream ">"
+            r exec
+
+            assert_replication_stream $repl {
+                {select *}
+                {xadd *}
+                {xadd *}
+                {xadd *}
+                {xgroup CREATE *}
+                {multi}
+                {xclaim *}
+                {xclaim *}
+                {xclaim *}
+                {exec}
+            }
+            close_replication_stream $repl
+        } {} {needs:repl}
+    }
+
+    foreach {cmd} {SAVE SHUTDOWN} {
+        test "MULTI with $cmd" {
+            r del foo
+            r multi
+            r set foo bar
+            catch {r $cmd} e1
+            catch {r exec} e2
+            assert_match {*Command not allowed inside a transaction*} $e1
+            assert_match {EXECABORT*} $e2
+            r get foo
+        } {}
+    }
+
+    test "MULTI with BGREWRITEAOF" {
+        set forks [s total_forks]
+        r multi
+        r set foo bar
+        r BGREWRITEAOF
+        set res [r exec]
+        assert_match "*rewriting scheduled*" [lindex $res 1]
+        wait_for_condition 50 100 {
+            [s total_forks] > $forks
+        } else {
+            fail "aofrw didn't start"
+        }
+        waitForBgrewriteaof r
+    } {} {external:skip}
+
+    test "MULTI with config set appendonly" {
+        set lines [count_log_lines 0]
+        set forks [s total_forks]
+        r multi
+        r set foo bar
+        r config set appendonly yes
+        r exec
+        verify_log_message 0 "*AOF background was scheduled*" $lines
+        wait_for_condition 50 100 {
+            [s total_forks] > $forks
+        } else {
+            fail "aofrw didn't start"
+        }
+        waitForBgrewriteaof r
+    } {} {external:skip}
+
+    test "MULTI with config error" {
+        r multi
+        r set foo bar
+        r config set maxmemory bla
+
+        # letting the redis parser read it, it'll throw an exception instead of
+        # reply with an array that contains an error, so we switch to reading
+        # raw RESP instead
+        r readraw 1
+
+        set res [r exec]
+        assert_equal $res "*2"
+        set res [r read]
+        assert_equal $res "+OK"
+        set res [r read]
+        r readraw 0
+        set _ $res
+    } {*CONFIG SET failed*}
+    }
+    
+    test "Flushall while watching several keys by one client" {
+        r flushall
+        r mset a{t} a b{t} b
+        r watch b{t} a{t}
+        r flushall
+        r ping
+     }
+}
+
+# --- Disabled (out of scope): AOF persistence is not modelled by jedis-mock. ---
+if 0 {
+start_server {overrides {appendonly {yes} appendfilename {appendonly.aof} appendfsync always} tags {external:skip}} {
+    test {MULTI with FLUSHALL and AOF} {
+        set aof [get_last_incr_aof_path r]
+        r multi
+        r set foo bar
+        r flushall
+        r exec
+        assert_aof_content $aof {
+            {multi}
+            {select *}
+            {set *}
+            {flushall}
+            {exec}
+        }
+        r get foo
+    } {}
+}
+}

--- a/src/main/java/com/github/fppt/jedismock/RedisClient.java
+++ b/src/main/java/com/github/fppt/jedismock/RedisClient.java
@@ -42,7 +42,8 @@ public final class RedisClient implements Runnable {
         Objects.requireNonNull(onClose);
         this.server = server;
         OperationExecutorState state = new OperationExecutorState(this,
-                server.getRedisBases(), server.getBlockingManager());
+                server.getRedisBases(), server.getBlockingManager(), server.getScriptingManager(),
+                server.getConfiguration());
         this.executor = new RedisOperationExecutor(state);
         this.socket = socket;
         this.in = socket.getInputStream();

--- a/src/main/java/com/github/fppt/jedismock/RedisServer.java
+++ b/src/main/java/com/github/fppt/jedismock/RedisServer.java
@@ -4,6 +4,8 @@ import com.github.fppt.jedismock.operations.CommandFactory;
 import com.github.fppt.jedismock.server.ServiceOptions;
 import com.github.fppt.jedismock.storage.BlockingManager;
 import com.github.fppt.jedismock.storage.RedisBase;
+import com.github.fppt.jedismock.storage.RedisConfiguration;
+import com.github.fppt.jedismock.storage.ScriptingManager;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -32,6 +34,8 @@ public class RedisServer {
     private final InetAddress bindAddress;
     private final Map<Integer, RedisBase> redisBases;
     private final BlockingManager blockingManager = new BlockingManager();
+    private final ScriptingManager scriptingManager = new ScriptingManager();
+    private final RedisConfiguration configuration = new RedisConfiguration();
     private volatile ExecutorService singleThreadPool;
     private volatile RedisServiceJob service;
     private volatile Clock clock = Clock.systemDefaultZone();
@@ -122,6 +126,14 @@ public class RedisServer {
 
     BlockingManager getBlockingManager() {
         return blockingManager;
+    }
+
+    ScriptingManager getScriptingManager() {
+        return scriptingManager;
+    }
+
+    RedisConfiguration getConfiguration() {
+        return configuration;
     }
 
     public ServiceOptions options() {

--- a/src/main/java/com/github/fppt/jedismock/operations/scripting/Eval.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/scripting/Eval.java
@@ -7,6 +7,7 @@ import com.github.fppt.jedismock.operations.scripting.cjson.LuaCjsonLib;
 import com.github.fppt.jedismock.server.Response;
 import com.github.fppt.jedismock.storage.OperationExecutorState;
 import com.github.fppt.jedismock.storage.RedisBase;
+import com.github.fppt.jedismock.storage.ScriptingManager;
 import org.luaj.vm2.Globals;
 import org.luaj.vm2.LuaError;
 import org.luaj.vm2.LuaString;
@@ -62,13 +63,22 @@ public class Eval extends AbstractRedisOperation {
         globals.set("ARGV", embedLuaListToValue(args.subList(keysNum, args.size())));
         globals.set("_mock", CoerceJavaToLua.coerce(new LuaRedisCallback(state)));
         globals.set("cjson", globals.load(new LuaCjsonLib()));
+        //Install a per-instruction hook so a concurrent SCRIPT KILL can abort
+        //this script, even a tight infinite loop.
+        final ScriptingManager scripting = state.scriptingManager();
+        globals.load(new InterruptibleDebugLib(scripting));
         int selected = state.getSelected();
+        scripting.start();
         try {
             final LuaValue result = globals.load(script).call();
             return resolveResult(result);
         } catch (LuaError e) {
+            if (scripting.isKillRequested()) {
+                return Response.error("Script killed by user with SCRIPT KILL...");
+            }
             return Response.error(String.format("Error running script: %s", e.getMessage()));
         } finally {
+            scripting.stop();
             state.changeActiveRedisBase(selected);
         }
     }

--- a/src/main/java/com/github/fppt/jedismock/operations/scripting/InterruptibleDebugLib.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/scripting/InterruptibleDebugLib.java
@@ -1,0 +1,51 @@
+package com.github.fppt.jedismock.operations.scripting;
+
+import com.github.fppt.jedismock.storage.ScriptingManager;
+import org.luaj.vm2.LuaError;
+import org.luaj.vm2.Varargs;
+import org.luaj.vm2.lib.DebugLib;
+
+/**
+ * A {@link DebugLib} whose per-instruction hook aborts the running script as
+ * soon as a {@code SCRIPT KILL} has been requested.
+ * <p>
+ * LuaJ's interpreter invokes {@link #onInstruction} before every VM instruction
+ * (see {@code LuaClosure.execute}), so this fires even inside a tight
+ * {@code while true do end} loop — it is the one place Java code can run while
+ * the script is otherwise stuck. Installing it via
+ * {@code globals.load(new InterruptibleDebugLib(...))} replaces the default
+ * debug library set up by {@code JsePlatform.standardGlobals()}; since that
+ * default already incurs the per-instruction callback, checking a single
+ * {@code volatile} flag adds no measurable overhead.
+ */
+public final class InterruptibleDebugLib extends DebugLib {
+    private final ScriptingManager scriptingManager;
+
+    public InterruptibleDebugLib(ScriptingManager scriptingManager) {
+        this.scriptingManager = scriptingManager;
+    }
+
+    @Override
+    public void onInstruction(int pc, Varargs v, int top) {
+        if (scriptingManager.isKillRequested()) {
+            throw new LuaError("Script killed by user with SCRIPT KILL...");
+        }
+        super.onInstruction(pc, v, top);
+    }
+
+    /**
+     * {@link org.luaj.vm2.LuaValue} defines {@code equals} as identity
+     * ({@code this == obj}) but no {@code hashCode}. Make both explicit and
+     * mutually consistent (identity semantics) so SpotBugs is satisfied; each
+     * debug-lib instance is a distinct object anyway.
+     */
+    @Override
+    public boolean equals(Object obj) {
+        return this == obj;
+    }
+
+    @Override
+    public int hashCode() {
+        return System.identityHashCode(this);
+    }
+}

--- a/src/main/java/com/github/fppt/jedismock/operations/server/Config.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/server/Config.java
@@ -11,15 +11,18 @@ import java.util.List;
 
 /**
  * Thin {@code CONFIG GET}/{@code CONFIG SET} support. The aim is not to model
- * real Redis configuration but to let clients that issue {@code CONFIG} under
- * the hood (e.g. Lettuce, Redisson) work, and to let a value written with
- * {@code SET} be read back with {@code GET}.
+ * real Redis configuration but to let code that issues {@code CONFIG} work
+ * (e.g. Spring Data Redis / Spring Session, which send
+ * {@code CONFIG SET notify-keyspace-events} automatically when a key-expiration
+ * listener is registered) and to let a value written with {@code SET} be read
+ * back with {@code GET}.
  * <p>
  * Most parameters are simply stored verbatim in a server-wide namespace
  * ({@link OperationExecutorState#configuration()}) and have no effect on the
- * mock. The exception is {@code lua-time-limit} (and its newer alias
- * {@code busy-reply-threshold}), which actually drives script-timeout behaviour
- * and is therefore routed to the {@link com.github.fppt.jedismock.storage.ScriptingManager}.
+ * mock. The exceptions are the behavioural parameters that the mock actually
+ * honours — {@code lua-time-limit} (alias {@code busy-reply-threshold}), routed
+ * to the {@link com.github.fppt.jedismock.storage.ScriptingManager}, and
+ * {@code proto-max-bulk-len}, routed to the configuration's typed accessor.
  * <p>
  * Glob-style patterns in {@code CONFIG GET} are not supported; each argument is
  * treated as a literal parameter name.
@@ -28,6 +31,7 @@ import java.util.List;
 class Config extends AbstractRedisOperation {
     private static final String LUA_TIME_LIMIT = "lua-time-limit";
     private static final String BUSY_REPLY_THRESHOLD = "busy-reply-threshold";
+    private static final String PROTO_MAX_BULK_LEN = "proto-max-bulk-len";
 
     private final OperationExecutorState state;
 
@@ -60,6 +64,8 @@ class Config extends AbstractRedisOperation {
             if (isLuaTimeLimit(name)) {
                 //Behavioural parameter: route to the component that uses it.
                 state.scriptingManager().setLuaTimeLimitMillis(Long.parseLong(value));
+            } else if (PROTO_MAX_BULK_LEN.equalsIgnoreCase(name)) {
+                state.configuration().setProtoMaxBulkLen(Long.parseLong(value));
             } else {
                 //Everything else just round-trips through the thin namespace.
                 state.configuration().set(name, value);
@@ -81,6 +87,9 @@ class Config extends AbstractRedisOperation {
     private String valueOf(String name) {
         if (isLuaTimeLimit(name)) {
             return Long.toString(state.scriptingManager().getLuaTimeLimitMillis());
+        }
+        if (PROTO_MAX_BULK_LEN.equalsIgnoreCase(name)) {
+            return Long.toString(state.configuration().getProtoMaxBulkLen());
         }
         return state.configuration().get(name);
     }

--- a/src/main/java/com/github/fppt/jedismock/operations/server/Config.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/server/Config.java
@@ -1,0 +1,91 @@
+package com.github.fppt.jedismock.operations.server;
+
+import com.github.fppt.jedismock.datastructures.Slice;
+import com.github.fppt.jedismock.operations.AbstractRedisOperation;
+import com.github.fppt.jedismock.operations.RedisCommand;
+import com.github.fppt.jedismock.server.Response;
+import com.github.fppt.jedismock.storage.OperationExecutorState;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Thin {@code CONFIG GET}/{@code CONFIG SET} support. The aim is not to model
+ * real Redis configuration but to let clients that issue {@code CONFIG} under
+ * the hood (e.g. Lettuce, Redisson) work, and to let a value written with
+ * {@code SET} be read back with {@code GET}.
+ * <p>
+ * Most parameters are simply stored verbatim in a server-wide namespace
+ * ({@link OperationExecutorState#configuration()}) and have no effect on the
+ * mock. The exception is {@code lua-time-limit} (and its newer alias
+ * {@code busy-reply-threshold}), which actually drives script-timeout behaviour
+ * and is therefore routed to the {@link com.github.fppt.jedismock.storage.ScriptingManager}.
+ * <p>
+ * Glob-style patterns in {@code CONFIG GET} are not supported; each argument is
+ * treated as a literal parameter name.
+ */
+@RedisCommand(value = "config", transactional = false)
+class Config extends AbstractRedisOperation {
+    private static final String LUA_TIME_LIMIT = "lua-time-limit";
+    private static final String BUSY_REPLY_THRESHOLD = "busy-reply-threshold";
+
+    private final OperationExecutorState state;
+
+    Config(OperationExecutorState state, List<Slice> params) {
+        super(state.base(), params);
+        this.state = state;
+    }
+
+    @Override
+    protected int minArgs() {
+        return 1;
+    }
+
+    @Override
+    protected Slice response() {
+        String subCommand = params().get(0).toString();
+        if ("SET".equalsIgnoreCase(subCommand)) {
+            return set();
+        } else if ("GET".equalsIgnoreCase(subCommand)) {
+            return get();
+        }
+        //RESETSTAT, REWRITE, etc.: accept as no-ops.
+        return Response.OK;
+    }
+
+    private Slice set() {
+        for (int i = 1; i + 1 < params().size(); i += 2) {
+            String name = params().get(i).toString();
+            String value = params().get(i + 1).toString();
+            if (isLuaTimeLimit(name)) {
+                //Behavioural parameter: route to the component that uses it.
+                state.scriptingManager().setLuaTimeLimitMillis(Long.parseLong(value));
+            } else {
+                //Everything else just round-trips through the thin namespace.
+                state.configuration().set(name, value);
+            }
+        }
+        return Response.OK;
+    }
+
+    private Slice get() {
+        List<Slice> result = new ArrayList<>();
+        for (int i = 1; i < params().size(); i++) {
+            String name = params().get(i).toString();
+            result.add(Response.bulkString(Slice.create(name)));
+            result.add(Response.bulkString(Slice.create(valueOf(name))));
+        }
+        return Response.array(result);
+    }
+
+    private String valueOf(String name) {
+        if (isLuaTimeLimit(name)) {
+            return Long.toString(state.scriptingManager().getLuaTimeLimitMillis());
+        }
+        return state.configuration().get(name);
+    }
+
+    private static boolean isLuaTimeLimit(String name) {
+        return LUA_TIME_LIMIT.equalsIgnoreCase(name) || BUSY_REPLY_THRESHOLD.equalsIgnoreCase(name);
+    }
+}

--- a/src/main/java/com/github/fppt/jedismock/operations/server/MockExecutor.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/server/MockExecutor.java
@@ -5,6 +5,7 @@ import com.github.fppt.jedismock.operations.CommandFactory;
 import com.github.fppt.jedismock.operations.RedisOperation;
 import com.github.fppt.jedismock.server.Response;
 import com.github.fppt.jedismock.storage.OperationExecutorState;
+import com.github.fppt.jedismock.storage.ScriptingManager;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
@@ -14,12 +15,71 @@ public class MockExecutor {
     private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(MockExecutor.class);
 
     /**
+     * Poll interval while waiting out a script that has not yet exceeded
+     * lua-time-limit. Small enough that a fast script adds negligible latency,
+     * large enough to avoid busy-spinning.
+     */
+    private static final long BUSY_POLL_MILLIS = 5L;
+
+    /**
+     * The reply real Redis gives to a command issued while a script is timing
+     * out. Kept verbatim so harmonized tests (and clients matching on it) behave
+     * identically to a real server.
+     */
+    private static final String BUSY_MESSAGE =
+            "BUSY Redis is busy running a script. You can only call SCRIPT KILL or SHUTDOWN NOSAVE.";
+
+    /**
      * Proceed with execution, mocking the Redis behaviour.
      * @param state Executor state, holding the shared database and connection-specific state.
      * @param name Command name.
      * @param commandParams Command parameters.
      */
     public static Slice proceed(OperationExecutorState state, String name, List<Slice> commandParams) {
+
+        //SCRIPT KILL must take effect while a runaway script still holds the
+        //global data lock, so it is handled here, before acquiring that lock.
+        //Otherwise it would block behind the very script it is meant to abort.
+        if ("script".equals(name) && !commandParams.isEmpty()
+                && "kill".equalsIgnoreCase(commandParams.get(0).toString())) {
+            ScriptingManager scripting = state.scriptingManager();
+            if (!scripting.requestKill()) {
+                return Response.error("NOTBUSY No scripts in execution right now.");
+            }
+            //Reply OK only once the script has actually aborted, so a command
+            //issued right after SCRIPT KILL no longer sees the script as busy.
+            scripting.awaitStopped();
+            return Response.OK;
+        }
+
+        //MULTI is allow-busy in real Redis and only flips this connection's
+        //transaction flag (no shared data), so service it without the data lock.
+        //Otherwise, while a script is busy, opening a transaction would either be
+        //rejected with BUSY or block behind the running script — and then a data
+        //command queued in that transaction could never get the BUSY error that
+        //must dirty it (so EXEC would not abort, as real Redis requires).
+        if ("multi".equals(name)) {
+            return CommandFactory.buildOperation(name, false, state, commandParams).execute();
+        }
+
+        //BUSY gate. While another connection runs a Lua script we must not block
+        //on the data lock (we could never wake to reply); instead we check the
+        //script's liveness *before* contending for the lock. A script that has
+        //exceeded lua-time-limit makes us reply -BUSY; a younger one makes us
+        //wait (polling, since a fast script finishes and we should then proceed).
+        //Done on the script thread itself this would deadlock, but a script's own
+        //redis.call goes through LuaRedisCallback, not here, so that can't happen.
+        //
+        //Note: this check is NOT atomic with acquiring the lock below. In a
+        //microsecond-wide window a *different* connection's script could start
+        //right after we observe "idle" here, so we would then block on the
+        //monitor instead of replying BUSY. Closing that race would mean replacing
+        //the intrinsic monitor with a ReentrantLock + Conditions (and migrating
+        //the blocking-op wait/notify too); deemed not worth it for a mock.
+        Slice busy = awaitScriptOrBusy(state, name);
+        if (busy != null) {
+            return busy;
+        }
 
         synchronized (state.lock()) {
             try {
@@ -49,6 +109,44 @@ public class MockExecutor {
                 return Response.error(e.getMessage());
             }
         }
+    }
+
+    /**
+     * If another connection is running a Lua script, wait for it: return a
+     * {@code -BUSY} reply once it has exceeded {@code lua-time-limit}, or
+     * {@code null} once it finishes (so the caller may proceed to the lock).
+     * Polls rather than blocking on the data lock, because a thread blocked on
+     * the monitor could never wake up to reply BUSY.
+     *
+     * @return the BUSY reply Slice, or {@code null} to proceed normally.
+     */
+    private static Slice awaitScriptOrBusy(OperationExecutorState state, String name) {
+        ScriptingManager scripting = state.scriptingManager();
+        while (scripting.isRunning()) {
+            if (scripting.isBusy()) {
+                if ("exec".equals(name) && state.isTransactionModeOn()) {
+                    //Real Redis rejects EXEC during a busy script and, because the
+                    //rejected command is EXEC, reports it as an aborted transaction
+                    //that names the cause, discarding the transaction. (Mirrors
+                    //the ERRORED branch of Exec, minus the generic message.)
+                    state.transactionMode(false);
+                    state.tx().clear();
+                    return Response.error("EXECABORT Transaction discarded because of: " + BUSY_MESSAGE);
+                }
+                //A data command rejected with BUSY while being queued in MULTI
+                //dirties the transaction, so a later EXEC aborts (matching real
+                //Redis); errorTransaction() is a no-op outside a transaction.
+                state.errorTransaction();
+                return Response.error(BUSY_MESSAGE);
+            }
+            try {
+                Thread.sleep(BUSY_POLL_MILLIS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return Response.SKIP;
+            }
+        }
+        return null;
     }
 
     /**

--- a/src/main/java/com/github/fppt/jedismock/operations/strings/Append.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/strings/Append.java
@@ -20,6 +20,11 @@ class Append extends AbstractRedisOperation {
         Slice value = params().get(1);
         RMString s = base().getRMString(key);
 
+        long currentLength = (s == null) ? 0 : s.size();
+        if (currentLength + value.length() > base().getProtoMaxBulkLen()) {
+            return Response.error("ERR string exceeds maximum allowed size (proto-max-bulk-len)");
+        }
+
         if (s == null) {
             base().putValue(key, value.extract());
             return Response.integer(value.length());

--- a/src/main/java/com/github/fppt/jedismock/operations/strings/SetRange.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/strings/SetRange.java
@@ -30,7 +30,10 @@ public class SetRange extends AbstractRedisOperation {
                 .map(RMString::getStoredDataAsString)
                 .orElse("");
         String padding = "";
-        if (offset + value.length() > base().getProtoMaxBulkLen()) {
+        //(long) cast: offset is an int near Integer.MAX_VALUE, so a plain
+        //int+int could overflow to a negative, skip this guard, and then attempt
+        //a multi-GB allocation below.
+        if ((long) offset + value.length() > base().getProtoMaxBulkLen()) {
             return Response.error("ERR string exceeds maximum allowed size (proto-max-bulk-len)");
         }
         if (offset > oldValue.length()) {

--- a/src/main/java/com/github/fppt/jedismock/storage/OperationExecutorState.java
+++ b/src/main/java/com/github/fppt/jedismock/storage/OperationExecutorState.java
@@ -46,7 +46,7 @@ public class OperationExecutorState {
     }
 
     public RedisBase base(int baseIndex) {
-        return redisBases.computeIfAbsent(baseIndex, key -> new RedisBase(this::getClock));
+        return redisBases.computeIfAbsent(baseIndex, key -> new RedisBase(this::getClock, configuration));
     }
 
     public RedisClient owner() {

--- a/src/main/java/com/github/fppt/jedismock/storage/OperationExecutorState.java
+++ b/src/main/java/com/github/fppt/jedismock/storage/OperationExecutorState.java
@@ -17,6 +17,8 @@ public class OperationExecutorState {
     private final RedisClient owner;
     private final Map<Integer, RedisBase> redisBases;
     private final BlockingManager blockingManager;
+    private final ScriptingManager scriptingManager;
+    private final RedisConfiguration configuration;
     private TransactionState transactionState = TransactionState.NORMAL;
     private final List<RedisOperation> tx = new ArrayList<>();
     private final Set<Slice> watchedKeys = new HashSet<>();
@@ -25,14 +27,18 @@ public class OperationExecutorState {
     private String clientName;
 
     public OperationExecutorState(RedisClient owner, Map<Integer, RedisBase> redisBases) {
-        this(owner, redisBases, new BlockingManager());
+        this(owner, redisBases, new BlockingManager(), new ScriptingManager(), new RedisConfiguration());
     }
 
     public OperationExecutorState(RedisClient owner, Map<Integer, RedisBase> redisBases,
-                                  BlockingManager blockingManager) {
+                                  BlockingManager blockingManager,
+                                  ScriptingManager scriptingManager,
+                                  RedisConfiguration configuration) {
         this.owner = owner;
         this.redisBases = redisBases;
         this.blockingManager = blockingManager;
+        this.scriptingManager = scriptingManager;
+        this.configuration = configuration;
     }
 
     public RedisBase base() {
@@ -90,6 +96,23 @@ public class OperationExecutorState {
      */
     public BlockingManager blockingManager() {
         return blockingManager;
+    }
+
+    /**
+     * @return the server-wide registry coordinating Lua script execution (used
+     * by {@code SCRIPT KILL}). Shared by every client of the same server.
+     */
+    public ScriptingManager scriptingManager() {
+        return scriptingManager;
+    }
+
+    /**
+     * @return the server-wide thin {@code CONFIG} namespace (a plain key→value
+     * store for parameters that don't affect mock behaviour). Shared by every
+     * client of the same server.
+     */
+    public RedisConfiguration configuration() {
+        return configuration;
     }
 
     /**

--- a/src/main/java/com/github/fppt/jedismock/storage/RedisBase.java
+++ b/src/main/java/com/github/fppt/jedismock/storage/RedisBase.java
@@ -28,9 +28,8 @@ import java.util.function.Supplier;
  * Created by Xiaolu on 2015/4/20.
  */
 public class RedisBase {
-    private static final long PROTO_MAX_BULK_LEN = 512 * 1024 * 1024; //512 MB by default
-
     private final Supplier<Clock> clockSupplier;
+    private final RedisConfiguration configuration;
     private final Map<Slice, Set<RedisClient>> subscribers = new HashMap<>();
     private final Map<Slice, Set<RedisClient>> psubscribers = new HashMap<>();
     private final Map<Slice, Set<OperationExecutorState>> watchedKeys = new HashMap<>();
@@ -38,7 +37,12 @@ public class RedisBase {
     private final ExpiringKeyValueStorage keyValueStorage;
 
     public RedisBase(Supplier<Clock> clockSupplier) {
+        this(clockSupplier, new RedisConfiguration());
+    }
+
+    public RedisBase(Supplier<Clock> clockSupplier, RedisConfiguration configuration) {
         this.clockSupplier = Objects.requireNonNull(clockSupplier);
+        this.configuration = Objects.requireNonNull(configuration);
         this.keyValueStorage = new ExpiringKeyValueStorage(clockSupplier, key -> watchedKeys
                 .getOrDefault(key, Collections.emptySet())
                 .forEach(OperationExecutorState::watchedKeyIsAffected));
@@ -328,7 +332,7 @@ public class RedisBase {
     }
 
     public long getProtoMaxBulkLen() {
-        return PROTO_MAX_BULK_LEN;
+        return configuration.getProtoMaxBulkLen();
     }
 
     public String getCachedLuaScript(String sha1) {

--- a/src/main/java/com/github/fppt/jedismock/storage/RedisBase.java
+++ b/src/main/java/com/github/fppt/jedismock/storage/RedisBase.java
@@ -18,7 +18,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -50,15 +49,22 @@ public class RedisBase {
     }
 
     public Set<Slice> keys() {
-        Iterator<Slice> slices = keyValueStorage.values().keySet().iterator();
+        Set<Slice> outdated = new HashSet<>();
         Set<Slice> result = new HashSet<>();
-        while (slices.hasNext()) {
-            Slice key = slices.next();
+        for (Slice key : keyValueStorage.values().keySet()) {
             if (keyValueStorage.isKeyOutdated(key)) {
-                slices.remove();
+                outdated.add(key);
             } else {
                 result.add(key);
             }
+        }
+        //Purge expired keys through the notifying delete (not a raw removal) so
+        //that WATCHers of an expired key are flagged: a passive expiry counts as
+        //a modification in real Redis, aborting a transaction that watched it.
+        //Otherwise a DBSIZE/KEYS sweep would drop the key silently and a later
+        //EXEC could no longer detect that the watched key had expired.
+        for (Slice key : outdated) {
+            keyValueStorage.delete(key);
         }
         return result;
     }

--- a/src/main/java/com/github/fppt/jedismock/storage/RedisConfiguration.java
+++ b/src/main/java/com/github/fppt/jedismock/storage/RedisConfiguration.java
@@ -9,8 +9,10 @@ import java.util.Map;
  * lets {@code CONFIG GET}/{@code CONFIG SET} round-trip arbitrary parameters.
  * <p>
  * The goal is <em>not</em> to model real Redis configuration, but simply to stop
- * clients that issue {@code CONFIG} under the hood (e.g. Lettuce, Redisson) from
- * failing with "unsupported operation", while letting a value written with
+ * code that issues {@code CONFIG} from failing with "unsupported operation" —
+ * notably Spring Data Redis / Spring Session, which send
+ * {@code CONFIG SET notify-keyspace-events} automatically when a key-expiration
+ * listener is registered — while letting a value written with
  * {@code SET} be read back with {@code GET}. Stored values do not change how the
  * mock behaves; the few parameters that <em>do</em> affect behaviour (currently
  * {@code lua-time-limit}) are handled by their owning component, not here.
@@ -23,7 +25,11 @@ import java.util.Map;
  * is read off-lock by the BUSY gate).
  */
 public final class RedisConfiguration {
+    /** Default {@code proto-max-bulk-len}, matching real Redis (512 MB). */
+    private static final long DEFAULT_PROTO_MAX_BULK_LEN = 512L * 1024 * 1024;
+
     private final Map<String, String> values = new HashMap<>();
+    private long protoMaxBulkLen = DEFAULT_PROTO_MAX_BULK_LEN;
 
     public void set(String key, String value) {
         values.put(key.toLowerCase(Locale.ROOT), value);
@@ -35,5 +41,24 @@ public final class RedisConfiguration {
      */
     public String get(String key) {
         return values.getOrDefault(key.toLowerCase(Locale.ROOT), "");
+    }
+
+    /**
+     * @return the configured {@code proto-max-bulk-len} — the largest string a
+     * command may build (enforced by {@code SETRANGE}/{@code APPEND}).
+     */
+    public long getProtoMaxBulkLen() {
+        return protoMaxBulkLen;
+    }
+
+    /**
+     * Set {@code proto-max-bulk-len}, capped at {@link Integer#MAX_VALUE}: the
+     * mock stores strings as {@code byte[]}, so it cannot honour a larger limit
+     * anyway. Reporting the cap back also makes real Redis's large-memory tests
+     * (which set this to many GB and then check it round-tripped) self-skip on
+     * the mock, exactly as they do on a 32-bit build.
+     */
+    public void setProtoMaxBulkLen(long protoMaxBulkLen) {
+        this.protoMaxBulkLen = Math.min(protoMaxBulkLen, Integer.MAX_VALUE);
     }
 }

--- a/src/main/java/com/github/fppt/jedismock/storage/RedisConfiguration.java
+++ b/src/main/java/com/github/fppt/jedismock/storage/RedisConfiguration.java
@@ -1,0 +1,39 @@
+package com.github.fppt.jedismock.storage;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * A thin, server-wide {@code CONFIG} namespace: a plain key→value store that
+ * lets {@code CONFIG GET}/{@code CONFIG SET} round-trip arbitrary parameters.
+ * <p>
+ * The goal is <em>not</em> to model real Redis configuration, but simply to stop
+ * clients that issue {@code CONFIG} under the hood (e.g. Lettuce, Redisson) from
+ * failing with "unsupported operation", while letting a value written with
+ * {@code SET} be read back with {@code GET}. Stored values do not change how the
+ * mock behaves; the few parameters that <em>do</em> affect behaviour (currently
+ * {@code lua-time-limit}) are handled by their owning component, not here.
+ * <p>
+ * Keys are treated case-insensitively, matching Redis. Server-wide, so the value
+ * is shared across all of a server's connections. Only the {@code CONFIG}
+ * command touches it, and that runs under the shared data lock
+ * ({@link OperationExecutorState#lock()}), so a plain {@link HashMap} suffices —
+ * no internal synchronization is needed (unlike {@link ScriptingManager}, which
+ * is read off-lock by the BUSY gate).
+ */
+public final class RedisConfiguration {
+    private final Map<String, String> values = new HashMap<>();
+
+    public void set(String key, String value) {
+        values.put(key.toLowerCase(Locale.ROOT), value);
+    }
+
+    /**
+     * @return the value previously {@link #set}, or an empty string if the key
+     * was never set (mirroring how real Redis reports an unset string parameter).
+     */
+    public String get(String key) {
+        return values.getOrDefault(key.toLowerCase(Locale.ROOT), "");
+    }
+}

--- a/src/main/java/com/github/fppt/jedismock/storage/ScriptingManager.java
+++ b/src/main/java/com/github/fppt/jedismock/storage/ScriptingManager.java
@@ -1,0 +1,120 @@
+package com.github.fppt.jedismock.storage;
+
+/**
+ * Server-wide coordination for Lua script execution. It serves two purposes:
+ * letting a {@code SCRIPT KILL} on one connection abort a script running on
+ * another, and letting other connections reply {@code -BUSY} once a script has
+ * run longer than {@code lua-time-limit}.
+ * <p>
+ * Scripts are serialized by the global data lock
+ * ({@link OperationExecutorState#lock()}), so at most one runs at a time;
+ * {@link #start()} and {@link #stop()} are therefore called by that single
+ * script thread while it holds the lock. Everything else must work <em>while</em>
+ * the script still holds that lock, so the remaining methods are deliberately
+ * lock-free and rely on {@code volatile} visibility.
+ * <p>
+ * The single-writer invariant (only the running-script thread calls
+ * {@code start}/{@code stop}) means {@code running} and {@code startNanos} can be
+ * plain volatiles: a reader that observes {@code running == true} is guaranteed
+ * by the volatile happens-before to also observe the matching {@code startNanos}.
+ */
+public final class ScriptingManager {
+    /**
+     * Default {@code lua-time-limit}, matching real Redis (5 seconds). A value of
+     * {@code 0} disables the limit (a script never becomes BUSY).
+     */
+    private static final long DEFAULT_LUA_TIME_LIMIT_MILLIS = 5000L;
+
+    private volatile boolean running = false;
+    private volatile long startNanos = 0L;
+    private volatile boolean killRequested = false;
+    private volatile long luaTimeLimitMillis = DEFAULT_LUA_TIME_LIMIT_MILLIS;
+
+    /**
+     * Mark the start of a script run, recording the start time and clearing any
+     * stale kill request left over from a previous script.
+     */
+    public void start() {
+        killRequested = false;
+        startNanos = System.nanoTime();
+        running = true;
+    }
+
+    /**
+     * Mark the end of a script run (normal completion, error, or kill).
+     */
+    public void stop() {
+        running = false;
+    }
+
+    /**
+     * Request termination of the currently running script.
+     *
+     * @return {@code true} if a script was running, so a kill has been scheduled
+     * and the caller should reply {@code OK}; {@code false} if nothing is
+     * running, so the caller should reply {@code -NOTBUSY}.
+     */
+    public boolean requestKill() {
+        if (!running) {
+            return false;
+        }
+        killRequested = true;
+        return true;
+    }
+
+    /**
+     * @return whether a {@code SCRIPT KILL} has been requested for the running
+     * script. Polled from the LuaJ instruction hook
+     * ({@code InterruptibleDebugLib}) so the script aborts promptly.
+     */
+    public boolean isKillRequested() {
+        return killRequested;
+    }
+
+    /**
+     * Block until the running script has actually stopped (its thread has called
+     * {@link #stop()}). Used by {@code SCRIPT KILL} so it replies {@code OK} only
+     * once the script is truly gone — matching real Redis, where the killer never
+     * races the aborting script. The script aborts at its next LuaJ instruction
+     * hook, so this returns almost immediately; it holds no lock, so it cannot
+     * deadlock against the script thread that still owns the data lock.
+     */
+    public void awaitStopped() {
+        while (running) {
+            try {
+                Thread.sleep(1L);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+        }
+    }
+
+    /**
+     * @return {@code true} if a script is currently running and has already run
+     * longer than {@code lua-time-limit}, so other clients should be answered
+     * with {@code -BUSY}. Always {@code false} when the limit is {@code 0}.
+     */
+    public boolean isBusy() {
+        if (!running) {
+            return false;
+        }
+        long limit = luaTimeLimitMillis;
+        return limit > 0 && (System.nanoTime() - startNanos) >= limit * 1_000_000L;
+    }
+
+    /**
+     * @return whether a script is currently running (regardless of how long).
+     */
+    public boolean isRunning() {
+        return running;
+    }
+
+    public long getLuaTimeLimitMillis() {
+        return luaTimeLimitMillis;
+    }
+
+    public void setLuaTimeLimitMillis(long luaTimeLimitMillis) {
+        this.luaTimeLimitMillis = luaTimeLimitMillis;
+    }
+}

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/scripting/ScriptBusyComparisonTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/scripting/ScriptBusyComparisonTest.java
@@ -1,0 +1,70 @@
+package com.github.fppt.jedismock.comparisontests.scripting;
+
+import com.github.fppt.jedismock.comparisontests.ComparisonBase;
+import com.github.fppt.jedismock.comparisontests.TestErrorMessages;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.exceptions.JedisDataException;
+
+import java.time.Duration;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Covers the {@code BUSY} reply: once a Lua script has run longer than
+ * {@code lua-time-limit}, real Redis keeps serving other connections but rejects
+ * ordinary commands with {@code -BUSY Redis is busy running a script...} (only
+ * {@code SCRIPT KILL} / {@code SHUTDOWN NOSAVE} are accepted). This is the other
+ * half of the {@code unit/multi.tcl} "MULTI and script timeout" deficiency: the
+ * mock ran every command under one global lock, so while a script looped, other
+ * clients blocked on that lock forever instead of getting a prompt BUSY.
+ *
+ * <p>The test lowers {@code lua-time-limit} (so the script becomes busy quickly),
+ * starts a runaway script on one connection, and asserts another connection is
+ * rejected with BUSY rather than wedged. The {@code assertTimeoutPreemptively}
+ * guard turns the old blocking behaviour into a clean failure ("deadlock")
+ * instead of a hung suite.
+ */
+@ExtendWith(ComparisonBase.class)
+public class ScriptBusyComparisonTest {
+
+    @TestTemplate
+    public void busyScriptRejectsOtherClientsWithBusyError(Jedis jedis, HostAndPort hostAndPort) {
+        // Lower the busy threshold so the script is flagged busy quickly.
+        jedis.configSet("lua-time-limit", "100");
+
+        Jedis busyClient = new Jedis(hostAndPort.getHost(), hostAndPort.getPort(), 1_000_000);
+        ExecutorService pool = Executors.newSingleThreadExecutor();
+        try {
+            pool.submit(() -> {
+                try {
+                    busyClient.eval("while true do end", 0);
+                } catch (Exception ignored) {
+                    // aborted by the SCRIPT KILL below -> error here
+                }
+            });
+
+            Assertions.assertTimeoutPreemptively(Duration.ofSeconds(5), () -> {
+                // Let the script exceed lua-time-limit and become "busy".
+                Thread.sleep(500);
+                // An ordinary command from another client must be rejected with
+                // BUSY rather than blocking on the lock held by the script.
+                assertThatThrownBy(() -> jedis.get("anykey"))
+                        .isInstanceOf(JedisDataException.class)
+                        .hasMessageContaining("BUSY");
+                // SCRIPT KILL is still accepted and restores normal operation.
+                jedis.scriptKill();
+                assertThat(jedis.ping()).isEqualTo("PONG");
+            }, TestErrorMessages.DEADLOCK_ERROR_MESSAGE);
+        } finally {
+            pool.shutdownNow();
+            busyClient.close();
+        }
+    }
+}

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/scripting/ScriptKillComparisonTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/scripting/ScriptKillComparisonTest.java
@@ -1,0 +1,85 @@
+package com.github.fppt.jedismock.comparisontests.scripting;
+
+import com.github.fppt.jedismock.comparisontests.ComparisonBase;
+import com.github.fppt.jedismock.comparisontests.TestErrorMessages;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.exceptions.JedisDataException;
+
+import java.time.Duration;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Covers {@code SCRIPT KILL}, which the mock previously did not implement at all.
+ *
+ * <p>This is the deficiency behind the hang of the {@code unit/multi.tcl} test
+ * "MULTI and script timeout" (and its "EXEC / MULTI-EXEC body and script
+ * timeout" siblings): those tests start a runaway
+ * {@code eval {while true do end} 0} and then issue {@code SCRIPT KILL} to abort
+ * it. The mock executes every command — {@code EVAL} included — under a single
+ * global lock, so a runaway script wedged the whole server and nothing could
+ * stop it.
+ *
+ * <p>The fix runs {@code SCRIPT KILL} on a lock-free path (it must take effect
+ * while the runaway script still holds the lock) and aborts the script through a
+ * LuaJ per-instruction hook. Each test asserts real-Redis behaviour, so both the
+ * "real" and "mock" variants pass.
+ */
+@ExtendWith(ComparisonBase.class)
+public class ScriptKillComparisonTest {
+
+    /**
+     * {@code SCRIPT KILL} with nothing running is a defined Redis command: it
+     * replies {@code -NOTBUSY No scripts in execution right now.} Fast and
+     * deterministic — no script involved.
+     */
+    @TestTemplate
+    public void scriptKillOnIdleServerReportsNotBusy(Jedis jedis) {
+        assertThatThrownBy(jedis::scriptKill)
+                .isInstanceOf(JedisDataException.class)
+                .hasMessageContaining("NOTBUSY");
+    }
+
+    /**
+     * A runaway script must not wedge the whole server: {@code SCRIPT KILL} from
+     * another connection terminates it and the server stays responsive. The
+     * {@code assertTimeoutPreemptively} guard turns a regression (the old
+     * deadlock) into a clean failure instead of a hung suite.
+     */
+    @TestTemplate
+    public void scriptKillTerminatesRunawayScript(Jedis jedis, HostAndPort hostAndPort) {
+        // Lower the busy threshold so SCRIPT KILL is permitted quickly.
+        jedis.configSet("lua-time-limit", "100");
+
+        Jedis busyClient = new Jedis(hostAndPort.getHost(), hostAndPort.getPort(), 1_000_000);
+        ExecutorService pool = Executors.newSingleThreadExecutor();
+        try {
+            pool.submit(() -> {
+                try {
+                    busyClient.eval("while true do end", 0);
+                } catch (Exception ignored) {
+                    // the script is aborted by SCRIPT KILL -> error here
+                }
+            });
+
+            Assertions.assertTimeoutPreemptively(Duration.ofSeconds(5), () -> {
+                // Let the script start and (on real Redis) become flagged busy.
+                Thread.sleep(500);
+                // Returns OK and unblocks the runaway script.
+                jedis.scriptKill();
+                // The server must remain responsive afterwards.
+                assertThat(jedis.ping()).isEqualTo("PONG");
+            }, TestErrorMessages.DEADLOCK_ERROR_MESSAGE);
+        } finally {
+            pool.shutdownNow();
+            busyClient.close();
+        }
+    }
+}

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/scripting/ScriptTimeoutExecComparisonTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/scripting/ScriptTimeoutExecComparisonTest.java
@@ -1,0 +1,97 @@
+package com.github.fppt.jedismock.comparisontests.scripting;
+
+import com.github.fppt.jedismock.comparisontests.ComparisonBase;
+import com.github.fppt.jedismock.comparisontests.TestErrorMessages;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.Protocol;
+import redis.clients.jedis.exceptions.JedisDataException;
+
+import java.time.Duration;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Faithful port of the {@code unit/multi.tcl} test "EXEC and script timeout".
+ *
+ * <p>Unlike "MULTI and script timeout", here {@code MULTI} and the first
+ * {@code INCR} are issued <em>before</em> the script starts (so they queue
+ * normally); the script then becomes busy and {@code EXEC} itself arrives during
+ * the timeout. Real Redis rejects {@code EXEC} during a busy script but, because
+ * the rejected command is {@code EXEC}, reports it as an aborted transaction
+ * that names the cause — matching {@code EXECABORT*BUSY*} rather than a bare
+ * {@code BUSY}. The transaction is discarded, so the connection is no longer in
+ * MULTI state afterwards.
+ */
+@ExtendWith(ComparisonBase.class)
+public class ScriptTimeoutExecComparisonTest {
+
+    @TestTemplate
+    public void execAndScriptTimeout(Jedis jedis, HostAndPort hostAndPort) {
+        jedis.configSet("lua-time-limit", "50");
+        jedis.set("xx", "1");
+
+        Jedis rd1 = new Jedis(hostAndPort.getHost(), hostAndPort.getPort(), 1_000_000);
+        Jedis r2 = new Jedis(hostAndPort.getHost(), hostAndPort.getPort(), 1_000_000);
+        ExecutorService pool = Executors.newSingleThreadExecutor();
+        try {
+            // MULTI and the first INCR are queued BEFORE the script runs.
+            r2.sendCommand(Protocol.Command.MULTI);
+            r2.sendCommand(Protocol.Command.INCR, "xx");
+
+            pool.submit(() -> {
+                try {
+                    rd1.eval("while true do end", 0);
+                } catch (Exception ignored) {
+                    // aborted by SCRIPT KILL below
+                }
+            });
+
+            Assertions.assertTimeoutPreemptively(Duration.ofSeconds(10), () -> {
+                Thread.sleep(300); // let the script exceed lua-time-limit
+
+                // A data command queued during the timeout is rejected with BUSY.
+                ignoringErrors(() -> r2.sendCommand(Protocol.Command.INCR, "xx"));
+
+                // EXEC arrives during the timeout -> EXECABORT naming the cause.
+                String execError = null;
+                try {
+                    r2.sendCommand(Protocol.Command.EXEC);
+                } catch (JedisDataException e) {
+                    execError = e.getMessage();
+                }
+                assertThat(execError)
+                        .as("EXEC during a busy script must abort and name the cause")
+                        .contains("EXECABORT")
+                        .contains("BUSY");
+
+                jedis.scriptKill();
+                Thread.sleep(300); // give the script time to actually abort
+
+                // Nothing from the transaction ran.
+                assertThat(jedis.get("xx")).isIn("1", "3");
+
+                // The connection is no longer in MULTI state: a PING with an
+                // argument echoes it back rather than returning QUEUED.
+                assertThat(r2.ping("asdf")).isEqualTo("asdf");
+            }, TestErrorMessages.DEADLOCK_ERROR_MESSAGE);
+        } finally {
+            pool.shutdownNow();
+            rd1.close();
+            r2.close();
+        }
+    }
+
+    private static void ignoringErrors(Runnable command) {
+        try {
+            command.run();
+        } catch (JedisDataException ignored) {
+            // mirrors the tcl `catch {...}`: BUSY is expected here
+        }
+    }
+}

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/scripting/ScriptTimeoutMultiComparisonTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/scripting/ScriptTimeoutMultiComparisonTest.java
@@ -1,0 +1,104 @@
+package com.github.fppt.jedismock.comparisontests.scripting;
+
+import com.github.fppt.jedismock.comparisontests.ComparisonBase;
+import com.github.fppt.jedismock.comparisontests.TestErrorMessages;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.Protocol;
+import redis.clients.jedis.exceptions.JedisDataException;
+
+import java.time.Duration;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Faithful port of the {@code unit/multi.tcl} test "MULTI and script timeout".
+ *
+ * <p>A runaway script is started on one connection; meanwhile another connection
+ * opens a {@code MULTI}, queues an {@code INCR} (which is rejected with BUSY
+ * because a script is timing out, dirtying the transaction), the script is
+ * killed, a second {@code INCR} is queued, and {@code EXEC} must then abort with
+ * {@code EXECABORT ... previous errors}. The counter must be left untouched and
+ * the connection must no longer be in MULTI state.
+ *
+ * <p>Raw {@code sendCommand} is used (rather than Jedis's {@code Transaction}
+ * helper) to mirror the tcl deferring/raw clients and to keep full control over
+ * which replies are errors. Each step that the tcl wraps in {@code catch} is
+ * wrapped here in a try/catch for the same reason.
+ *
+ * <p>This exercises the interplay of the BUSY gate with transactions: data
+ * commands rejected with BUSY during {@code MULTI} dirty the transaction, while
+ * the transaction-control commands themselves are still serviced.
+ */
+@ExtendWith(ComparisonBase.class)
+public class ScriptTimeoutMultiComparisonTest {
+
+    @TestTemplate
+    public void multiAndScriptTimeout(Jedis jedis, HostAndPort hostAndPort) {
+        jedis.configSet("lua-time-limit", "50");
+        jedis.set("xx", "1");
+
+        Jedis rd1 = new Jedis(hostAndPort.getHost(), hostAndPort.getPort(), 1_000_000);
+        Jedis r2 = new Jedis(hostAndPort.getHost(), hostAndPort.getPort(), 1_000_000);
+        ExecutorService pool = Executors.newSingleThreadExecutor();
+        try {
+            pool.submit(() -> {
+                try {
+                    rd1.eval("while true do end", 0);
+                } catch (Exception ignored) {
+                    // aborted by SCRIPT KILL below
+                }
+            });
+
+            Assertions.assertTimeoutPreemptively(Duration.ofSeconds(10), () -> {
+                Thread.sleep(300); // let the script exceed lua-time-limit
+
+                // MULTI arrives during the timeout: it is serviced (the tcl
+                // comment allows "refused, or allowed to pass").
+                ignoringErrors(() -> r2.sendCommand(Protocol.Command.MULTI));
+                // INCR is a data command -> rejected with BUSY -> dirties the tx.
+                ignoringErrors(() -> r2.sendCommand(Protocol.Command.INCR, "xx"));
+
+                jedis.scriptKill();
+                Thread.sleep(300); // give the script time to actually abort
+
+                ignoringErrors(() -> r2.sendCommand(Protocol.Command.INCR, "xx"));
+
+                String execError = null;
+                try {
+                    r2.sendCommand(Protocol.Command.EXEC);
+                } catch (JedisDataException e) {
+                    execError = e.getMessage();
+                }
+                assertThat(execError)
+                        .as("EXEC must abort because a command errored while queued")
+                        .contains("EXECABORT")
+                        .contains("previous errors");
+
+                // The transaction ran wholly or not at all (we expect not at all).
+                assertThat(jedis.get("xx")).isIn("1", "3");
+
+                // The connection is no longer in MULTI state: a PING with an
+                // argument echoes it back rather than returning QUEUED.
+                assertThat(r2.ping("asdf")).isEqualTo("asdf");
+            }, TestErrorMessages.DEADLOCK_ERROR_MESSAGE);
+        } finally {
+            pool.shutdownNow();
+            rd1.close();
+            r2.close();
+        }
+    }
+
+    private static void ignoringErrors(Runnable command) {
+        try {
+            command.run();
+        } catch (JedisDataException ignored) {
+            // mirrors the tcl `catch {...}`: BUSY / queue errors are expected
+        }
+    }
+}

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/server/ConfigComparisonTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/server/ConfigComparisonTest.java
@@ -1,22 +1,38 @@
 package com.github.fppt.jedismock.comparisontests.server;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
+import redis.clients.jedis.exceptions.JedisDataException;
 
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
- * Thin {@code CONFIG} support (issue #40): clients such as Lettuce and Redisson
- * issue {@code CONFIG} under the hood and must not fail with "unsupported
- * operation". The mock stores parameters in a separate namespace and round-trips
- * them, without otherwise changing behaviour.
+ * Thin {@code CONFIG} support (issue #40): code that issues {@code CONFIG} must
+ * not fail with "unsupported operation" — notably Spring Data Redis / Spring
+ * Session, which send {@code CONFIG SET notify-keyspace-events} automatically
+ * when a key-expiration listener is registered. The mock stores parameters in a
+ * separate namespace and round-trips them, without otherwise changing behaviour.
  */
 @ExtendWith(ComparisonBase.class)
 public class ConfigComparisonTest {
+
+    /**
+     * Restore the parameters these tests change to their defaults. In an
+     * {@code @AfterEach} (not at the end of each test) so it runs even when a
+     * test fails — otherwise a changed value would leak into the shared
+     * (per-class) mock and real-Redis servers.
+     */
+    @AfterEach
+    public void restoreDefaults(Jedis jedis) {
+        jedis.configSet("proto-max-bulk-len", "536870912");
+        jedis.configSet("maxmemory-policy", "noeviction");
+    }
 
     @TestTemplate
     public void getOfUnsetParameterReturnsEmptyValue(Jedis jedis) {
@@ -29,7 +45,35 @@ public class ConfigComparisonTest {
         assertThat(jedis.configSet("maxmemory-policy", "allkeys-lru")).isEqualTo("OK");
         assertThat(jedis.configGet("maxmemory-policy"))
                 .containsEntry("maxmemory-policy", "allkeys-lru");
-        // Restore the default so the shared real-Redis container isn't left altered.
-        jedis.configSet("maxmemory-policy", "noeviction");
+    }
+
+    /**
+     * {@code proto-max-bulk-len} is a behavioural parameter: it caps the size of
+     * a string a command may build. 1 MiB is real Redis's minimum, so it round-
+     * trips on both, and SETRANGE checks the bound without allocating.
+     */
+    @TestTemplate
+    public void protoMaxBulkLenRoundTripsAndBoundsSetrange(Jedis jedis) {
+        assertThat(jedis.configSet("proto-max-bulk-len", "1048576")).isEqualTo("OK");
+        assertThat(jedis.configGet("proto-max-bulk-len"))
+                .containsEntry("proto-max-bulk-len", "1048576");
+
+        jedis.del("bulk");
+        // A result within the limit is fine...
+        assertThat(jedis.setrange("bulk", 100, "world")).isEqualTo(105L);
+        // ...one that would exceed it is rejected (no large allocation needed).
+        assertThatThrownBy(() -> jedis.setrange("bulk", 1048573, "world"))
+                .isInstanceOf(JedisDataException.class)
+                .hasMessageContaining("maximum allowed size");
+    }
+
+    @TestTemplate
+    public void appendBeyondProtoMaxBulkLenIsRejected(Jedis jedis) {
+        jedis.configSet("proto-max-bulk-len", "1048576");
+        jedis.del("big");
+        jedis.set("big", "a".repeat(1048576)); // exactly at the limit
+        assertThatThrownBy(() -> jedis.append("big", "x"))
+                .isInstanceOf(JedisDataException.class)
+                .hasMessageContaining("maximum allowed size");
     }
 }

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/server/ConfigComparisonTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/server/ConfigComparisonTest.java
@@ -1,0 +1,35 @@
+package com.github.fppt.jedismock.comparisontests.server;
+
+import com.github.fppt.jedismock.comparisontests.ComparisonBase;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import redis.clients.jedis.Jedis;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Thin {@code CONFIG} support (issue #40): clients such as Lettuce and Redisson
+ * issue {@code CONFIG} under the hood and must not fail with "unsupported
+ * operation". The mock stores parameters in a separate namespace and round-trips
+ * them, without otherwise changing behaviour.
+ */
+@ExtendWith(ComparisonBase.class)
+public class ConfigComparisonTest {
+
+    @TestTemplate
+    public void getOfUnsetParameterReturnsEmptyValue(Jedis jedis) {
+        Map<String, String> result = jedis.configGet("requirepass");
+        assertThat(result).containsEntry("requirepass", "");
+    }
+
+    @TestTemplate
+    public void setThenGetRoundTripsTheValue(Jedis jedis) {
+        assertThat(jedis.configSet("maxmemory-policy", "allkeys-lru")).isEqualTo("OK");
+        assertThat(jedis.configGet("maxmemory-policy"))
+                .containsEntry("maxmemory-policy", "allkeys-lru");
+        // Restore the default so the shared real-Redis container isn't left altered.
+        jedis.configSet("maxmemory-policy", "noeviction");
+    }
+}

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/transactions/WatchExpiredKeyComparisonTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/transactions/WatchExpiredKeyComparisonTest.java
@@ -1,0 +1,48 @@
+package com.github.fppt.jedismock.comparisontests.transactions;
+
+import com.github.fppt.jedismock.comparisontests.ComparisonBase;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.Transaction;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Port of the {@code unit/multi.tcl} test "WATCH will consider touched expired
+ * keys": a key that expires <em>after</em> it is watched must be treated as
+ * modified, so a following {@code MULTI}/.../{@code EXEC} aborts and returns nil.
+ *
+ * <p>The subtlety the mock got wrong: the tcl test forces a {@code DBSIZE} sweep
+ * (via {@code wait_for_dbsize 0}) before {@code EXEC}. That sweep purged the
+ * expired key, but silently — without flagging the watcher — so the later
+ * {@code EXEC} could no longer notice the key had expired and ran the
+ * transaction instead of aborting it.
+ */
+@ExtendWith(ComparisonBase.class)
+public class WatchExpiredKeyComparisonTest {
+
+    @TestTemplate
+    public void watchConsidersTouchedExpiredKeys(Jedis jedis) {
+        jedis.flushAll();
+        jedis.del("x");
+        jedis.set("x", "foo");
+        jedis.pexpire("x", 50);
+        jedis.watch("x");
+
+        // Wait for the key to expire AND for a DBSIZE sweep to observe it gone —
+        // mirroring the tcl `wait_for_dbsize 0`, which is what purges the key.
+        Awaitility.await().atMost(Duration.ofSeconds(2))
+                .until(() -> jedis.dbSize() == 0);
+
+        // The watched key expired, so the transaction must abort: EXEC -> nil.
+        Transaction transaction = jedis.multi();
+        transaction.get("x");
+        assertThat(transaction.exec())
+                .as("EXEC must abort (nil) because the watched key expired")
+                .isNull();
+    }
+}

--- a/src/test/java/com/github/fppt/jedismock/storage/RedisConfigurationTest.java
+++ b/src/test/java/com/github/fppt/jedismock/storage/RedisConfigurationTest.java
@@ -1,0 +1,36 @@
+package com.github.fppt.jedismock.storage;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RedisConfigurationTest {
+
+    @Test
+    void unsetParameterReadsBackAsEmpty() {
+        RedisConfiguration config = new RedisConfiguration();
+        assertThat(config.get("requirepass")).isEmpty();
+    }
+
+    @Test
+    void setValueRoundTripsCaseInsensitively() {
+        RedisConfiguration config = new RedisConfiguration();
+        config.set("Maxmemory-Policy", "allkeys-lru");
+        assertThat(config.get("maxmemory-policy")).isEqualTo("allkeys-lru");
+    }
+
+    @Test
+    void protoMaxBulkLenDefaultsTo512Mb() {
+        assertThat(new RedisConfiguration().getProtoMaxBulkLen()).isEqualTo(512L * 1024 * 1024);
+    }
+
+    @Test
+    void protoMaxBulkLenIsCappedAtIntegerMaxValue() {
+        // The mock stores strings as byte[], so it cannot honour a multi-GB
+        // limit; capping it is also what makes real Redis's large-memory tests
+        // (set proto-max-bulk-len to 10gb, then check it round-tripped) self-skip.
+        RedisConfiguration config = new RedisConfiguration();
+        config.setProtoMaxBulkLen(10_000_000_000L);
+        assertThat(config.getProtoMaxBulkLen()).isEqualTo(Integer.MAX_VALUE);
+    }
+}


### PR DESCRIPTION
## Summary

Makes the Redis `unit/multi.tcl` test suite pass against jedis-mock and adds it to the native-tests CI job. Getting there required three behavioural additions — Lua **script-timeout** handling, **thin `CONFIG GET/SET`**, and a **WATCH-on-expiry** fix. Every behavioural change is backed by a mock-vs-real comparison test (`@TestTemplate` running the same code against `redis:7.4-alpine` and the mock).

## Changes

### Lua script timeouts: `SCRIPT KILL` and `BUSY`
A long-running (or infinite) script previously held the single global data lock forever, wedging the whole server.

- **`SCRIPT KILL`** (new): handled on a lock-free path in `MockExecutor` (it must take effect while the runaway script still holds the lock) and aborts the script via a LuaJ per-instruction hook (`InterruptibleDebugLib`) — the one place Java can run inside a tight `while true do end`. Replies `OK` only once the script has actually stopped, or `-NOTBUSY` when nothing is running.
- **`BUSY` replies**: a pre-lock gate answers `-BUSY Redis is busy running a script...` once a script exceeds `lua-time-limit`, instead of blocking. `EXEC` during a busy script returns `EXECABORT ... because of: BUSY ...`, and a data command rejected mid-`MULTI` dirties the transaction — matching real Redis.
- New server-wide `ScriptingManager` coordinates this (lock-free volatile state, since it's read off-lock by the gate).

### Thin `CONFIG GET` / `CONFIG SET`
`CONFIG` used to fail with "unsupported operation" (issue #40 — e.g. Spring Data Redis / Spring Session issue `CONFIG SET notify-keyspace-events` automatically when a key-expiration listener is registered).

- Arbitrary parameters are accepted and round-trip through a server-wide namespace (`RedisConfiguration`) without affecting the mock; an unset parameter reads back as `""`, matching real Redis. No glob-pattern support.
- Two parameters are **behavioural**: `lua-time-limit` (alias `busy-reply-threshold`) drives the script timeout above; `proto-max-bulk-len` bounds the largest string a command may build.

### `proto-max-bulk-len`
- Now configurable (was a hardcoded 512MB), enforced by `SETRANGE` and `APPEND` (`-ERR string exceeds maximum allowed size`). Capped at `Integer.MAX_VALUE` (the mock stores strings as `byte[]`), which also keeps real Redis's multi-GB large-memory tests self-skipping on the mock.
- Fixed a latent `int` overflow in the `SETRANGE` bound check (`offset + len` could wrap negative and skip the guard).

### WATCH considers touched expired keys
`RedisBase.keys()` (used by `DBSIZE`/`KEYS`) purged expired keys with a raw removal that bypassed the watch-notifier, so a `DBSIZE` sweep could drop a watched key without flagging its watcher and a later `EXEC` would not abort. It now purges via the notifying delete, so a passive expiry correctly invalidates a transaction.

### TCL suite + CI
- Enabled `unit/multi.tcl`; tests requiring out-of-scope features (replica state / `REPLICAOF`, OOM enforcement, replication-stream propagation, AOF / `BGREWRITEAOF`, `SAVE` / `SHUTDOWN`) are disabled with `if 0 { ... }` (original text kept verbatim) and a comment explaining why. Verified the file still parses (`tclsh info complete`).
- Added a `multi` step to `.github/workflows/native-tests.yml`.

### Docs
- README: new `CONFIG GET/SET` and "Script timeouts: `BUSY` / `SCRIPT KILL`" sections.

## Tests
New comparison tests (mock vs. real Redis): `ScriptKillComparisonTest`, `ScriptBusyComparisonTest`, `ScriptTimeoutExecComparisonTest`, `ScriptTimeoutMultiComparisonTest`, `ConfigComparisonTest`, `WatchExpiredKeyComparisonTest`. Existing transaction / scripting / expiration suites remain green.

Closes #40. Fixes #773.
