### PR TITLE
keyspace notifications  for the generic (g) and expired (x) event classes

### DIFF
--- a/native_tests/jm-test-server/src/main/java/com/github/fppt/jedismock/InterceptorMockServer.java
+++ b/native_tests/jm-test-server/src/main/java/com/github/fppt/jedismock/InterceptorMockServer.java
@@ -29,10 +29,7 @@ public final class InterceptorMockServer {
         RedisServer
                 .newRedisServer(PORT)
                 .setOptions(ServiceOptions.withInterceptor((state, roName, params) -> {
-                    if ("config".equalsIgnoreCase(roName)) {
-                        //Just a junk response instead of an error
-                        return Response.bulkString(Slice.create("1"));
-                    } else if ("debug".equalsIgnoreCase(roName)
+                    if ("debug".equalsIgnoreCase(roName)
                             && "object".equalsIgnoreCase(params.get(0).toString())
                     ) {
                         // Handling unsopported DEBUG OBJECT command

--- a/native_tests/linux/tests/unit/pubsub.tcl
+++ b/native_tests/linux/tests/unit/pubsub.tcl
@@ -453,6 +453,7 @@ start_server {tags {"pubsub network"}} {
         $rd1 close
         r config set maxmemory-policy noeviction
     } {OK} {needs:config-maxmemory}
+    }
 
     test "Keyspace notifications: test CONFIG GET/SET of event flags" {
         r config set notify-keyspace-events gKE
@@ -465,6 +466,9 @@ start_server {tags {"pubsub network"}} {
         assert_equal {AE} [lindex [r config get notify-keyspace-events] 1]
     }
 
+    # Notification emission is not implemented in jedis-mock yet
+    # (issues #406/#809); re-enable when it is.
+    if 0 {
     test "Keyspace notifications: new key test" {
         r config set notify-keyspace-events En
         set rd1 [redis_deferring_client]

--- a/native_tests/linux/tests/unit/pubsub.tcl
+++ b/native_tests/linux/tests/unit/pubsub.tcl
@@ -259,8 +259,8 @@ start_server {tags {"pubsub network"}} {
 
     ### Keyspace events notification tests
 
-    # Keyspace notifications are not implemented in jedis-mock yet
-    # (issues #406/#809); re-enable these tests when they are.
+    # These need string-class ('$') events, which are not implemented yet
+    # (issue #406); the generic and expired classes below do work.
     if 0 {
     test "Keyspace notifications: we receive keyspace notifications" {
         r config set notify-keyspace-events KA
@@ -307,6 +307,8 @@ start_server {tags {"pubsub network"}} {
         $rd1 close
     }
 
+    }
+
     test "Keyspace notifications: general events test" {
         r config set notify-keyspace-events KEg
         set rd1 [redis_deferring_client]
@@ -321,6 +323,8 @@ start_server {tags {"pubsub network"}} {
         $rd1 close
     }
 
+    # Type-specific event classes are not implemented yet (issue #406).
+    if 0 {
     test "Keyspace notifications: list events test" {
         r config set notify-keyspace-events KEl
         r del mylist
@@ -404,6 +408,8 @@ start_server {tags {"pubsub network"}} {
         $rd1 close
     }
 
+    }
+
     test "Keyspace notifications: expired events (triggered expire)" {
         r config set notify-keyspace-events Ex
         r del foo
@@ -419,6 +425,16 @@ start_server {tags {"pubsub network"}} {
         $rd1 close
     }
 
+    # Disabled: jedis-mock expires keys lazily (on access) and has no active
+    # expiry cycle, so a key nobody touches never produces an 'expired' event.
+    #
+    # The next test is disabled for a different reason: an expiration set in the
+    # past deletes the key immediately, which Redis reports as a generic 'del'
+    # (verified against redis 7.4) while Valkey reports 'expired'. jedis-mock
+    # follows Redis here, so this Valkey-only expectation cannot hold.
+    #
+    # The evicted-events test needs maxmemory, which jedis-mock does not model.
+    if 0 {
     test "Keyspace notifications: expired events (background expire)" {
         r config set notify-keyspace-events Ex
         r del foo
@@ -466,8 +482,7 @@ start_server {tags {"pubsub network"}} {
         assert_equal {AE} [lindex [r config get notify-keyspace-events] 1]
     }
 
-    # Notification emission is not implemented in jedis-mock yet
-    # (issues #406/#809); re-enable when it is.
+    # The 'n' (new key) event class is not implemented yet (issue #406).
     if 0 {
     test "Keyspace notifications: new key test" {
         r config set notify-keyspace-events En

--- a/src/main/java/com/github/fppt/jedismock/operations/connection/Client.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/connection/Client.java
@@ -30,6 +30,22 @@ public class Client implements RedisOperation {
         } else if ("getname".equalsIgnoreCase(subcommand)) {
             String name = state.getClientName();
             return name == null ? Response.NULL : Response.bulkString(Slice.create(name));
+        } else if ("reply".equalsIgnoreCase(subcommand)) {
+            if (params.size() != 2) {
+                return Response.error("ERR wrong number of arguments for 'client|reply' command");
+            }
+            // The +OK returned below is itself subject to the mode just set:
+            // OperationExecutorState.applyReplyMode suppresses it for OFF/SKIP.
+            final String mode = params.get(1).toString();
+            if ("on".equalsIgnoreCase(mode)) {
+                state.replyOn();
+            } else if ("off".equalsIgnoreCase(mode)) {
+                state.replyOff();
+            } else if ("skip".equalsIgnoreCase(mode)) {
+                state.replySkip();
+            } else {
+                return Response.error("ERR syntax error");
+            }
         }
         return Response.clientResponse("client", Response.OK);
     }

--- a/src/main/java/com/github/fppt/jedismock/operations/connection/Client.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/connection/Client.java
@@ -7,6 +7,7 @@ import com.github.fppt.jedismock.datastructures.Slice;
 import com.github.fppt.jedismock.storage.OperationExecutorState;
 
 import java.util.List;
+import java.util.Locale;
 
 @RedisCommand(value = "client", transactional = false)
 public class Client implements RedisOperation {
@@ -26,13 +27,19 @@ public class Client implements RedisOperation {
         }
         final String subcommand = params.get(0).toString();
         if ("setname".equalsIgnoreCase(subcommand)) {
+            if (params.size() != 2) {
+                return wrongNumberOfArguments(subcommand);
+            }
             state.setClientName(params.get(1).toString());
         } else if ("getname".equalsIgnoreCase(subcommand)) {
+            if (params.size() != 1) {
+                return wrongNumberOfArguments(subcommand);
+            }
             String name = state.getClientName();
             return name == null ? Response.NULL : Response.bulkString(Slice.create(name));
         } else if ("reply".equalsIgnoreCase(subcommand)) {
             if (params.size() != 2) {
-                return Response.error("ERR wrong number of arguments for 'client|reply' command");
+                return wrongNumberOfArguments(subcommand);
             }
             // The +OK returned below is itself subject to the mode just set:
             // OperationExecutorState.applyReplyMode suppresses it for OFF/SKIP.
@@ -47,6 +54,15 @@ public class Client implements RedisOperation {
                 return Response.error("ERR syntax error");
             }
         }
+        //Unknown subcommands are accepted as no-ops rather than rejected the way
+        //real Redis does: clients send informational ones we do not model (for
+        //instance Lettuce's CLIENT SETINFO and CLIENT MAINT_NOTIFICATIONS on
+        //connect), and failing those would break the connection handshake.
         return Response.clientResponse("client", Response.OK);
+    }
+
+    private static Slice wrongNumberOfArguments(String subcommand) {
+        return Response.error(String.format("ERR wrong number of arguments for 'client|%s' command",
+                subcommand.toLowerCase(Locale.ROOT)));
     }
 }

--- a/src/main/java/com/github/fppt/jedismock/operations/keys/Copy.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/keys/Copy.java
@@ -6,6 +6,7 @@ import com.github.fppt.jedismock.datastructures.Slice;
 import com.github.fppt.jedismock.operations.RedisCommand;
 import com.github.fppt.jedismock.operations.RedisOperation;
 import com.github.fppt.jedismock.server.Response;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.OperationExecutorState;
 import com.github.fppt.jedismock.storage.RedisBase;
 
@@ -71,6 +72,8 @@ public class Copy implements RedisOperation {
         if (deadline != null) {
             destinationBase.setDeadline(destination, deadline);
         }
+        //Only the destination key is reported
+        destinationBase.notifyKeyspaceEvent(KeyspaceEvent.COPY_TO, destination);
         //Key copied
         return Response.integer(1);
     }

--- a/src/main/java/com/github/fppt/jedismock/operations/keys/Del.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/keys/Del.java
@@ -4,6 +4,7 @@ import com.github.fppt.jedismock.operations.AbstractRedisOperation;
 import com.github.fppt.jedismock.operations.RedisCommand;
 import com.github.fppt.jedismock.server.Response;
 import com.github.fppt.jedismock.datastructures.Slice;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.RedisBase;
 
 import java.util.List;
@@ -17,8 +18,10 @@ class Del extends AbstractRedisOperation {
     protected Slice response() {
         int count = 0;
         for (Slice key : params()) {
+            //An already-expired key is reported as 'expired' by exists(), not deleted here
             if (base().exists(key)) {
                 base().deleteValue(key);
+                base().notifyKeyspaceEvent(KeyspaceEvent.DEL, key);
                 count++;
             }
         }

--- a/src/main/java/com/github/fppt/jedismock/operations/keys/Move.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/keys/Move.java
@@ -6,6 +6,7 @@ import com.github.fppt.jedismock.datastructures.Slice;
 import com.github.fppt.jedismock.operations.RedisCommand;
 import com.github.fppt.jedismock.operations.RedisOperation;
 import com.github.fppt.jedismock.server.Response;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.OperationExecutorState;
 import com.github.fppt.jedismock.storage.RedisBase;
 
@@ -48,6 +49,9 @@ public class Move implements RedisOperation {
             destinationBase.setDeadline(key, deadline);
         }
         state.base().deleteValue(key);
+        state.base().notifyKeyspaceEvent(KeyspaceEvent.MOVE_FROM, key);
+        //move_to belongs to the destination database, so it is published on its channels
+        destinationBase.notifyKeyspaceEvent(KeyspaceEvent.MOVE_TO, key);
         return Response.integer(1);
     }
 }

--- a/src/main/java/com/github/fppt/jedismock/operations/keys/PExpire.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/keys/PExpire.java
@@ -7,6 +7,7 @@ import com.github.fppt.jedismock.operations.keys.paramsparser.ExpirationExtraPar
 import com.github.fppt.jedismock.operations.keys.paramsparser.ExpirationParamsException;
 import com.github.fppt.jedismock.operations.keys.paramsparser.ExpirationTimeParam;
 import com.github.fppt.jedismock.server.Response;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.RedisBase;
 
 import java.util.List;
@@ -38,7 +39,16 @@ class PExpire extends AbstractRedisOperation {
             long newTTL = expirationTime.getMillis();
             if (base().exists(key) && extraParam.checkTiming(
                     base().getTTL(key), newTTL)) {
-                return Response.integer(base().setTTL(key, newTTL));
+                if (newTTL <= 0) {
+                    //An expiration in the past deletes the key immediately, and is
+                    //reported as a 'del' rather than an 'expired'
+                    base().deleteValue(key);
+                    base().notifyKeyspaceEvent(KeyspaceEvent.DEL, key);
+                    return Response.integer(1);
+                }
+                long result = base().setTTL(key, newTTL);
+                base().notifyKeyspaceEvent(KeyspaceEvent.EXPIRE, key);
+                return Response.integer(result);
             } else return Response.integer(0);
         } catch (ExpirationParamsException e) {
             return Response.error(e.getMessage());

--- a/src/main/java/com/github/fppt/jedismock/operations/keys/PExpireAt.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/keys/PExpireAt.java
@@ -7,6 +7,7 @@ import com.github.fppt.jedismock.operations.keys.paramsparser.ExpirationExtraPar
 import com.github.fppt.jedismock.operations.keys.paramsparser.ExpirationParamsException;
 import com.github.fppt.jedismock.operations.keys.paramsparser.ExpirationTimeParam;
 import com.github.fppt.jedismock.server.Response;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.RedisBase;
 
 import java.util.List;
@@ -37,7 +38,16 @@ class PExpireAt extends AbstractRedisOperation {
             long newDeadline = expirationTime.getMillis();
             if (base().exists(key) && extraParam.checkTiming(
                     base().getDeadline(key), newDeadline)) {
-                return Response.integer(base().setDeadline(key, newDeadline));
+                if (newDeadline <= base().getClock().millis()) {
+                    //A deadline in the past deletes the key immediately, and is
+                    //reported as a 'del' rather than an 'expired'
+                    base().deleteValue(key);
+                    base().notifyKeyspaceEvent(KeyspaceEvent.DEL, key);
+                    return Response.integer(1);
+                }
+                long result = base().setDeadline(key, newDeadline);
+                base().notifyKeyspaceEvent(KeyspaceEvent.EXPIRE, key);
+                return Response.integer(result);
             } else return Response.integer(0);
         } catch (ExpirationParamsException e) {
             return Response.error(e.getMessage());

--- a/src/main/java/com/github/fppt/jedismock/operations/keys/Persist.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/keys/Persist.java
@@ -4,6 +4,7 @@ import com.github.fppt.jedismock.datastructures.Slice;
 import com.github.fppt.jedismock.operations.AbstractRedisOperation;
 import com.github.fppt.jedismock.operations.RedisCommand;
 import com.github.fppt.jedismock.server.Response;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.RedisBase;
 
 import java.util.List;
@@ -15,6 +16,12 @@ class Persist extends AbstractRedisOperation {
     }
 
     protected Slice response() {
-        return Response.integer(base().setDeadline(params().get(0), -1));
+        Slice key = params().get(0);
+        long result = base().setDeadline(key, -1);
+        if (result == 1) {
+            //Only an actually removed TTL is reported
+            base().notifyKeyspaceEvent(KeyspaceEvent.PERSIST, key);
+        }
+        return Response.integer(result);
     }
 }

--- a/src/main/java/com/github/fppt/jedismock/operations/keys/Rename.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/keys/Rename.java
@@ -5,6 +5,7 @@ import com.github.fppt.jedismock.datastructures.Slice;
 import com.github.fppt.jedismock.operations.AbstractRedisOperation;
 import com.github.fppt.jedismock.operations.RedisCommand;
 import com.github.fppt.jedismock.server.Response;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.OperationExecutorState;
 
 import java.util.List;
@@ -28,6 +29,8 @@ class Rename extends AbstractRedisOperation {
         base().deleteValue(newKey);
         base().putValue(newKey, value, ttl);
         base().deleteValue(key);
+        base().notifyKeyspaceEvent(KeyspaceEvent.RENAME_FROM, key);
+        base().notifyKeyspaceEvent(KeyspaceEvent.RENAME_TO, newKey);
         lock.notifyAll();
 
         return true;

--- a/src/main/java/com/github/fppt/jedismock/operations/pubsub/Publish.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/pubsub/Publish.java
@@ -2,15 +2,12 @@ package com.github.fppt.jedismock.operations.pubsub;
 
 import com.github.fppt.jedismock.operations.AbstractRedisOperation;
 import com.github.fppt.jedismock.operations.RedisCommand;
-import com.github.fppt.jedismock.RedisClient;
 import com.github.fppt.jedismock.server.Response;
 import com.github.fppt.jedismock.datastructures.Slice;
 import com.github.fppt.jedismock.storage.RedisBase;
 import com.github.fppt.jedismock.storage.SubscriptionRegistry;
 
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 @RedisCommand("publish")
 class Publish extends AbstractRedisOperation {
@@ -24,24 +21,6 @@ class Publish extends AbstractRedisOperation {
     protected Slice response(){
         Slice channel = params().get(0);
         Slice message = params().get(1);
-
-        Set<RedisClient> subscribers = registry.getSubscribers(channel);
-
-        subscribers.forEach(subscriber -> {
-            Slice response = Response.publishedMessage(channel, message);
-            subscriber.sendResponse(response, "contacting subscriber");
-        });
-
-        Map<Slice, Set<RedisClient>> patternsPsubscribers = registry.getPsubscribers(channel);
-        int totalClientsPsubscribed = patternsPsubscribers.entrySet().stream().map(mapEntry -> {
-            Slice pattern = mapEntry.getKey();
-            Set<RedisClient> psubscribedClients = mapEntry.getValue();
-            psubscribedClients.forEach(psubscriber->{
-                Slice response = Response.publishedPMessage(pattern, channel, message);
-                psubscriber.sendResponse(response, "contacting subscriber");
-            });
-            return psubscribedClients.size();
-        }).reduce(0, Integer::sum);
-        return Response.integer(subscribers.size() + totalClientsPsubscribed);
+        return Response.integer(registry.publish(channel, message));
     }
 }

--- a/src/main/java/com/github/fppt/jedismock/operations/scripting/Eval.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/scripting/Eval.java
@@ -68,26 +68,32 @@ public class Eval extends AbstractRedisOperation {
             return Response.error("ERR Number of keys can't be greater than number of args");
         }
 
-        /*
-        An alias for 'unpack' function: unpack() was moved to table.unpack() in Lua 5.2,
-        but Redis uses Lua 5.1.
-         */
-        globals.set("unpack", globals.load("return table.unpack(...)").checkfunction());
-        globals.set("redis", globals.load(REDIS_LUA).call().checktable());
-        globals.set("KEYS", embedLuaListToValue(args.subList(0, keysNum)));
-        globals.set("ARGV", embedLuaListToValue(args.subList(keysNum, args.size())));
-        globals.set("_mock", CoerceJavaToLua.coerce(new LuaRedisCallback(state)));
-        globals.set("cjson", globals.load(new LuaCjsonLib()));
-        //Install a per-instruction hook so a concurrent SCRIPT KILL can abort
-        //this script, even a tight infinite loop.
         final ScriptingManager scripting = state.scriptingManager();
-        globals.load(new InterruptibleDebugLib(scripting));
-        //Lock down the environment (read-only globals, no host access) and run the
-        //user script inside it, exactly as real Redis sandboxes Lua.
-        final LuaTable sandbox = LuaSandbox.install(globals, state);
         int selected = state.getSelected();
+        //Mark the script as running *before* building the Lua environment, which
+        //is slow the first time (luaj compiles REDIS_LUA, cjson and the sandbox).
+        //We already hold the data lock, so a command arriving on another
+        //connection meanwhile must not observe "no script running": it would then
+        //block on that lock and could never be answered. Seeing a running script
+        //instead makes it wait for lua-time-limit and reply -BUSY.
         scripting.start();
         try {
+            /*
+            An alias for 'unpack' function: unpack() was moved to table.unpack() in Lua 5.2,
+            but Redis uses Lua 5.1.
+             */
+            globals.set("unpack", globals.load("return table.unpack(...)").checkfunction());
+            globals.set("redis", globals.load(REDIS_LUA).call().checktable());
+            globals.set("KEYS", embedLuaListToValue(args.subList(0, keysNum)));
+            globals.set("ARGV", embedLuaListToValue(args.subList(keysNum, args.size())));
+            globals.set("_mock", CoerceJavaToLua.coerce(new LuaRedisCallback(state)));
+            globals.set("cjson", globals.load(new LuaCjsonLib()));
+            //Install a per-instruction hook so a concurrent SCRIPT KILL can abort
+            //this script, even a tight infinite loop.
+            globals.load(new InterruptibleDebugLib(scripting));
+            //Lock down the environment (read-only globals, no host access) and run the
+            //user script inside it, exactly as real Redis sandboxes Lua.
+            final LuaTable sandbox = LuaSandbox.install(globals, state);
             //Load under a fixed chunk name so error locations read "user_script:N"
             //(as in real Redis) instead of echoing the whole script body.
             final LuaValue chunk = globals.load(script, "@user_script");

--- a/src/main/java/com/github/fppt/jedismock/operations/server/Config.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/server/Config.java
@@ -4,6 +4,7 @@ import com.github.fppt.jedismock.datastructures.Slice;
 import com.github.fppt.jedismock.operations.AbstractRedisOperation;
 import com.github.fppt.jedismock.operations.RedisCommand;
 import com.github.fppt.jedismock.server.Response;
+import com.github.fppt.jedismock.storage.KeyspaceNotificationOptions;
 import com.github.fppt.jedismock.storage.OperationExecutorState;
 
 import java.util.ArrayList;
@@ -32,6 +33,7 @@ class Config extends AbstractRedisOperation {
     private static final String LUA_TIME_LIMIT = "lua-time-limit";
     private static final String BUSY_REPLY_THRESHOLD = "busy-reply-threshold";
     private static final String PROTO_MAX_BULK_LEN = "proto-max-bulk-len";
+    private static final String NOTIFY_KEYSPACE_EVENTS = "notify-keyspace-events";
 
     private final OperationExecutorState state;
 
@@ -66,6 +68,15 @@ class Config extends AbstractRedisOperation {
                 state.scriptingManager().setLuaTimeLimitMillis(Long.parseLong(value));
             } else if (PROTO_MAX_BULK_LEN.equalsIgnoreCase(name)) {
                 state.configuration().setProtoMaxBulkLen(Long.parseLong(value));
+            } else if (NOTIFY_KEYSPACE_EVENTS.equalsIgnoreCase(name)) {
+                try {
+                    state.configuration().setKeyspaceNotificationOptions(
+                            KeyspaceNotificationOptions.parse(value));
+                } catch (IllegalArgumentException e) {
+                    return Response.error(String.format(
+                            "ERR CONFIG SET failed (possibly related to argument '%s') - %s",
+                            NOTIFY_KEYSPACE_EVENTS, e.getMessage()));
+                }
             } else {
                 //Everything else just round-trips through the thin namespace.
                 state.configuration().set(name, value);
@@ -90,6 +101,10 @@ class Config extends AbstractRedisOperation {
         }
         if (PROTO_MAX_BULK_LEN.equalsIgnoreCase(name)) {
             return Long.toString(state.configuration().getProtoMaxBulkLen());
+        }
+        if (NOTIFY_KEYSPACE_EVENTS.equalsIgnoreCase(name)) {
+            //Reported in canonical form, not as originally written.
+            return state.configuration().getKeyspaceNotificationOptions().format();
         }
         return state.configuration().get(name);
     }

--- a/src/main/java/com/github/fppt/jedismock/operations/strings/GetDel.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/strings/GetDel.java
@@ -4,6 +4,7 @@ import com.github.fppt.jedismock.datastructures.Slice;
 import com.github.fppt.jedismock.operations.AbstractRedisOperation;
 import com.github.fppt.jedismock.operations.RedisCommand;
 import com.github.fppt.jedismock.server.Response;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.RedisBase;
 
 import java.util.List;
@@ -18,6 +19,7 @@ public class GetDel extends AbstractRedisOperation {
         Slice slice = base().getSlice(params().get(0));
         if (slice != null) {
             base().deleteValue(params().get(0));
+            base().notifyKeyspaceEvent(KeyspaceEvent.DEL, params().get(0));
         }
         return Response.bulkString(slice);
     }

--- a/src/main/java/com/github/fppt/jedismock/operations/strings/Set.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/strings/Set.java
@@ -6,6 +6,7 @@ import com.github.fppt.jedismock.operations.AbstractRedisOperation;
 import com.github.fppt.jedismock.operations.RedisCommand;
 import com.github.fppt.jedismock.server.Response;
 import com.github.fppt.jedismock.datastructures.Slice;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.RedisBase;
 
 import java.util.List;
@@ -87,26 +88,43 @@ class Set extends AbstractRedisOperation {
         return value;
     }
 
+    /**
+     * Setting an expiration alongside the value publishes a generic
+     * {@code expire} notification (in addition to the string-class {@code set}
+     * one), exactly as a separate {@code EXPIRE} would.
+     */
+    private void notifyExpirationSet(Slice key) {
+        base().notifyKeyspaceEvent(KeyspaceEvent.EXPIRE, key);
+    }
+
     private BiConsumer<Slice, RMDataStructure> valueSetter() {
         String previous = null;
         for (String param : additionalParams) {
             if ("ex".equalsIgnoreCase(previous)) {
                 long ex = parseAndValidate(param, 1000);
-                return (k, v) -> base().putValue(k, v, ex);
+                return (k, v) -> {
+                    base().putValue(k, v, ex);
+                    notifyExpirationSet(k);
+                };
             } else if ("px".equalsIgnoreCase(previous)) {
                 long px = parseAndValidate(param, 1);
-                return (k, v) -> base().putValue(k, v, px);
+                return (k, v) -> {
+                    base().putValue(k, v, px);
+                    notifyExpirationSet(k);
+                };
             } else if ("exat".equalsIgnoreCase(previous)) {
                 long exat = parseAndValidate(param, 1000);
                 return (k, v) -> {
                     base().putValue(k, v);
                     base().setDeadline(k, exat);
+                    notifyExpirationSet(k);
                 };
             } else if ("pxat".equalsIgnoreCase(previous)) {
                 long pxat = parseAndValidate(param, 1);
                 return (k, v) -> {
                     base().putValue(k, v);
                     base().setDeadline(k, pxat);
+                    notifyExpirationSet(k);
                 };
             }
             previous = param;

--- a/src/main/java/com/github/fppt/jedismock/operations/strings/SetEx.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/strings/SetEx.java
@@ -1,6 +1,7 @@
 package com.github.fppt.jedismock.operations.strings;
 
 import com.github.fppt.jedismock.operations.RedisCommand;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.RedisBase;
 import com.github.fppt.jedismock.server.Response;
 import com.github.fppt.jedismock.datastructures.Slice;
@@ -31,6 +32,8 @@ class SetEx extends Set {
             return Response.error(String.format("ERR invalid expire time in '%s' command", self().value()));
         }
         base().putValue(params().get(0), params().get(2).extract(), timeout);
+        //As with SET ... EX, the expiration is reported as a generic 'expire'
+        base().notifyKeyspaceEvent(KeyspaceEvent.EXPIRE, params().get(0));
         return Response.OK;
     }
 }

--- a/src/main/java/com/github/fppt/jedismock/server/RedisOperationExecutor.java
+++ b/src/main/java/com/github/fppt/jedismock/server/RedisOperationExecutor.java
@@ -32,12 +32,13 @@ public class RedisOperationExecutor {
     }
 
     /**
-     * Releases the server-side state of a disconnected client
-     * (its pub/sub subscriptions).
+     * Releases the server-side state of a disconnected client (its pub/sub
+     * subscriptions). Deliberately does not take the shared data lock: a client
+     * may disconnect while another connection runs a long Lua script that holds
+     * it, and the disconnect must not wait for that script to finish. The
+     * registry guards itself instead.
      */
     public void cleanup() {
-        synchronized (state.lock()) {
-            state.subscriptionRegistry().removeClient(state.owner());
-        }
+        state.subscriptionRegistry().removeClient(state.owner());
     }
 }

--- a/src/main/java/com/github/fppt/jedismock/server/RedisOperationExecutor.java
+++ b/src/main/java/com/github/fppt/jedismock/server/RedisOperationExecutor.java
@@ -23,8 +23,12 @@ public class RedisOperationExecutor {
         List<Slice> params = command.parameters();
         List<Slice> commandParams = params.subList(1, params.size());
         String name = new String(params.get(0).data()).toLowerCase();
-        return state.owner().options().getCommandInterceptor()
+        Slice response = state.owner().options().getCommandInterceptor()
                 .execCommand(state, name, commandParams);
+        // CLIENT REPLY applies to the socket reply path only: replies produced
+        // inside Lua or MULTI go through MockExecutor.proceed directly and are
+        // part of a larger reply, which is never suppressed piecemeal.
+        return state.applyReplyMode(response);
     }
 
     /**

--- a/src/main/java/com/github/fppt/jedismock/storage/ExpiringKeyValueStorage.java
+++ b/src/main/java/com/github/fppt/jedismock/storage/ExpiringKeyValueStorage.java
@@ -13,9 +13,22 @@ import java.util.function.Supplier;
 
 public class ExpiringKeyValueStorage extends ExpiringStorage {
     private final Map<Slice, RMDataStructure> values = new HashMap<>();
+    private final Consumer<Slice> expiredKeyNotifier;
 
-    public ExpiringKeyValueStorage(Supplier<Clock> clockSupplier, Consumer<Slice> keyChangeNotifier) {
+    public ExpiringKeyValueStorage(Supplier<Clock> clockSupplier, Consumer<Slice> keyChangeNotifier,
+                                   Consumer<Slice> expiredKeyNotifier) {
         super(clockSupplier, keyChangeNotifier);
+        this.expiredKeyNotifier = Objects.requireNonNull(expiredKeyNotifier);
+    }
+
+    /**
+     * Removes a key that has outlived its TTL. Separate from {@link #delete}
+     * so that a passive expiry can be reported as an {@code expired} keyspace
+     * notification rather than a {@code del}.
+     */
+    public void deleteExpired(Slice key) {
+        delete(key);
+        expiredKeyNotifier.accept(key);
     }
 
     public Map<Slice, RMDataStructure> values() {
@@ -81,7 +94,7 @@ public class ExpiringKeyValueStorage extends ExpiringStorage {
         }
 
         if (isKeyOutdated(key)) {
-            delete(key);
+            deleteExpired(key);
             return false;
         }
 

--- a/src/main/java/com/github/fppt/jedismock/storage/KeyspaceEvent.java
+++ b/src/main/java/com/github/fppt/jedismock/storage/KeyspaceEvent.java
@@ -1,0 +1,42 @@
+package com.github.fppt.jedismock.storage;
+
+import com.github.fppt.jedismock.storage.KeyspaceNotificationOptions.EventClass;
+
+/**
+ * A keyspace-notification event: the name Redis publishes for it and the
+ * event class that {@code notify-keyspace-events} enables it with.
+ * <p>
+ * Every event belongs to exactly one class, so the two travel together here
+ * rather than being passed side by side — a caller cannot pair an event with
+ * the wrong class. The published name is held explicitly because it is part of
+ * the wire protocol and does not always match the Java constant (for instance
+ * {@code xgroup-create}, which is not a valid identifier).
+ */
+public enum KeyspaceEvent {
+    DEL("del", EventClass.GENERIC),
+    EXPIRE("expire", EventClass.GENERIC),
+    PERSIST("persist", EventClass.GENERIC),
+    RENAME_FROM("rename_from", EventClass.GENERIC),
+    RENAME_TO("rename_to", EventClass.GENERIC),
+    MOVE_FROM("move_from", EventClass.GENERIC),
+    MOVE_TO("move_to", EventClass.GENERIC),
+    COPY_TO("copy_to", EventClass.GENERIC),
+    EXPIRED("expired", EventClass.EXPIRED);
+
+    private final String eventName;
+    private final EventClass eventClass;
+
+    KeyspaceEvent(String eventName, EventClass eventClass) {
+        this.eventName = eventName;
+        this.eventClass = eventClass;
+    }
+
+    /** The event name as published, e.g. {@code rename_from}. */
+    public String eventName() {
+        return eventName;
+    }
+
+    public EventClass eventClass() {
+        return eventClass;
+    }
+}

--- a/src/main/java/com/github/fppt/jedismock/storage/KeyspaceNotificationOptions.java
+++ b/src/main/java/com/github/fppt/jedismock/storage/KeyspaceNotificationOptions.java
@@ -1,0 +1,114 @@
+package com.github.fppt.jedismock.storage;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
+
+/**
+ * The parsed value of the {@code notify-keyspace-events} configuration
+ * parameter: which keyspace-notification event classes are enabled, and on
+ * which of the two channel families ({@code K} = {@code __keyspace@<db>__:<key>},
+ * {@code E} = {@code __keyevent@<db>__:<event>}) they are published.
+ * <p>
+ * Immutable; {@link #parse} and {@link #format} mirror real Redis exactly,
+ * including the {@code A} alias, the canonical character order reported by
+ * {@code CONFIG GET}, and the error message for an unknown character
+ * (pinned by {@code NotifyKeyspaceEventsConfigTest} against real Redis).
+ */
+public final class KeyspaceNotificationOptions {
+
+    /**
+     * Event classes, declared in the canonical order Redis uses when
+     * formatting the flag string: the classes covered by the {@code A} alias
+     * ({@link #GENERIC} through {@link #MODULE}), then {@link #NEW},
+     * {@link #KEYSPACE}, {@link #KEYEVENT} and {@link #KEY_MISS}.
+     */
+    public enum EventClass {
+        GENERIC('g'),
+        STRING('$'),
+        LIST('l'),
+        SET('s'),
+        HASH('h'),
+        ZSET('z'),
+        EXPIRED('x'),
+        EVICTED('e'),
+        STREAM('t'),
+        MODULE('d'),
+        NEW('n'),
+        KEYSPACE('K'),
+        KEYEVENT('E'),
+        KEY_MISS('m');
+
+        private final char code;
+
+        EventClass(char code) {
+            this.code = code;
+        }
+
+        public char code() {
+            return code;
+        }
+    }
+
+    public static final KeyspaceNotificationOptions DISABLED =
+            new KeyspaceNotificationOptions(EnumSet.noneOf(EventClass.class));
+
+    /** The classes the {@code A} alias stands for: everything except K, E, n and m. */
+    private static final Set<EventClass> ALL_ALIAS =
+            Collections.unmodifiableSet(EnumSet.range(EventClass.GENERIC, EventClass.MODULE));
+
+    private final Set<EventClass> classes;
+
+    private KeyspaceNotificationOptions(EnumSet<EventClass> classes) {
+        this.classes = Collections.unmodifiableSet(classes);
+    }
+
+    /**
+     * @throws IllegalArgumentException on an unknown character, with the exact
+     * message real Redis embeds in the {@code CONFIG SET} error reply
+     */
+    public static KeyspaceNotificationOptions parse(String flags) {
+        EnumSet<EventClass> classes = EnumSet.noneOf(EventClass.class);
+        nextCharacter:
+        for (char c : flags.toCharArray()) {
+            if (c == 'A') {
+                classes.addAll(ALL_ALIAS);
+                continue;
+            }
+            for (EventClass eventClass : EventClass.values()) {
+                if (eventClass.code == c) {
+                    classes.add(eventClass);
+                    continue nextCharacter;
+                }
+            }
+            throw new IllegalArgumentException("Invalid event class character. Use 'Ag$lshzxeKEtmdn'.");
+        }
+        return new KeyspaceNotificationOptions(classes);
+    }
+
+    public boolean isEnabled(EventClass eventClass) {
+        return classes.contains(eventClass);
+    }
+
+    /**
+     * The canonical form reported by {@code CONFIG GET}: the {@code A} alias
+     * collapses the classes it covers, followed by the remaining flags in
+     * declaration order.
+     */
+    public String format() {
+        StringBuilder result = new StringBuilder();
+        if (classes.containsAll(ALL_ALIAS)) {
+            result.append('A');
+            for (EventClass eventClass : EnumSet.range(EventClass.NEW, EventClass.KEY_MISS)) {
+                if (classes.contains(eventClass)) {
+                    result.append(eventClass.code);
+                }
+            }
+        } else {
+            for (EventClass eventClass : classes) {
+                result.append(eventClass.code);
+            }
+        }
+        return result.toString();
+    }
+}

--- a/src/main/java/com/github/fppt/jedismock/storage/KeyspaceNotificationOptions.java
+++ b/src/main/java/com/github/fppt/jedismock/storage/KeyspaceNotificationOptions.java
@@ -90,6 +90,10 @@ public final class KeyspaceNotificationOptions {
         return classes.contains(eventClass);
     }
 
+    public boolean isEnabled(KeyspaceEvent event) {
+        return isEnabled(event.eventClass());
+    }
+
     /**
      * The canonical form reported by {@code CONFIG GET}: the {@code A} alias
      * collapses the classes it covers, followed by the remaining flags in

--- a/src/main/java/com/github/fppt/jedismock/storage/OperationExecutorState.java
+++ b/src/main/java/com/github/fppt/jedismock/storage/OperationExecutorState.java
@@ -126,8 +126,9 @@ public class OperationExecutorState {
     /**
      * @return the server-wide registry of channel and pattern subscriptions.
      * Pub/Sub is independent of the key space, so the registry is shared by
-     * every client and every database of the same server; only mutate it
-     * while holding {@link #lock()}.
+     * every client and every database of the same server. It synchronizes
+     * itself and is deliberately not covered by {@link #lock()}, so that a
+     * disconnecting client never waits behind a running script.
      */
     public SubscriptionRegistry subscriptionRegistry() {
         return subscriptionRegistry;

--- a/src/main/java/com/github/fppt/jedismock/storage/OperationExecutorState.java
+++ b/src/main/java/com/github/fppt/jedismock/storage/OperationExecutorState.java
@@ -3,6 +3,7 @@ package com.github.fppt.jedismock.storage;
 import com.github.fppt.jedismock.datastructures.Slice;
 import com.github.fppt.jedismock.operations.RedisOperation;
 import com.github.fppt.jedismock.RedisClient;
+import com.github.fppt.jedismock.server.Response;
 
 import java.time.Clock;
 import java.util.ArrayList;
@@ -26,6 +27,8 @@ public class OperationExecutorState {
     private boolean watchedKeysAffected = false;
     private int selectedRedisBase = 0;
     private String clientName;
+    private boolean repliesDisabled = false;
+    private int repliesToSkip = 0;
 
     public OperationExecutorState(RedisClient owner, Map<Integer, RedisBase> redisBases) {
         this(owner, redisBases, new BlockingManager(), new ScriptingManager(), new RedisConfiguration(),
@@ -50,7 +53,8 @@ public class OperationExecutorState {
     }
 
     public RedisBase base(int baseIndex) {
-        return redisBases.computeIfAbsent(baseIndex, key -> new RedisBase(this::getClock, configuration));
+        return redisBases.computeIfAbsent(baseIndex,
+                key -> new RedisBase(this::getClock, configuration, subscriptionRegistry, key));
     }
 
     public RedisClient owner() {
@@ -190,5 +194,43 @@ public class OperationExecutorState {
 
     public String getClientName() {
         return clientName;
+    }
+
+    /** {@code CLIENT REPLY ON}: resume replying (and always reply +OK itself). */
+    public void replyOn() {
+        repliesDisabled = false;
+        repliesToSkip = 0;
+    }
+
+    /** {@code CLIENT REPLY OFF}: suppress all command replies until ON. */
+    public void replyOff() {
+        repliesDisabled = true;
+    }
+
+    /**
+     * {@code CLIENT REPLY SKIP}: suppress the reply to this command and to
+     * the next one. A no-op while replies are OFF, matching real Redis.
+     */
+    public void replySkip() {
+        if (!repliesDisabled) {
+            repliesToSkip = 2;
+        }
+    }
+
+    /**
+     * Applies the {@code CLIENT REPLY} mode to a command reply. Called only on
+     * the socket command-reply path — never for pub/sub pushes (subscribe
+     * acknowledgements, published messages), which real Redis delivers even
+     * while replies are silenced.
+     */
+    public Slice applyReplyMode(Slice response) {
+        if (repliesToSkip > 0) {
+            repliesToSkip--;
+            return Response.SKIP;
+        }
+        if (repliesDisabled) {
+            return Response.SKIP;
+        }
+        return response;
     }
 }

--- a/src/main/java/com/github/fppt/jedismock/storage/RedisBase.java
+++ b/src/main/java/com/github/fppt/jedismock/storage/RedisBase.java
@@ -45,7 +45,8 @@ public class RedisBase {
         this.dbIndex = dbIndex;
         this.keyValueStorage = new ExpiringKeyValueStorage(clockSupplier, key -> watchedKeys
                 .getOrDefault(key, Collections.emptySet())
-                .forEach(OperationExecutorState::watchedKeyIsAffected));
+                .forEach(OperationExecutorState::watchedKeyIsAffected),
+                key -> notifyKeyspaceEvent(KeyspaceEvent.EXPIRED, key));
     }
 
     /**
@@ -57,19 +58,19 @@ public class RedisBase {
      * {@code __keyevent@<db>__:<event> -> <key>}. Only call while holding
      * {@link OperationExecutorState#lock()} (all operations do).
      */
-    public void notifyKeyspaceEvent(KeyspaceNotificationOptions.EventClass eventClass, String event, Slice key) {
+    public void notifyKeyspaceEvent(KeyspaceEvent event, Slice key) {
         KeyspaceNotificationOptions options = configuration.getKeyspaceNotificationOptions();
-        if (!options.isEnabled(eventClass)) {
+        if (!options.isEnabled(event)) {
             return;
         }
         if (options.isEnabled(KeyspaceNotificationOptions.EventClass.KEYSPACE)) {
             subscriptionRegistry.publish(
                     channel("__keyspace@" + dbIndex + "__:", key.data()),
-                    Slice.create(event));
+                    Slice.create(event.eventName()));
         }
         if (options.isEnabled(KeyspaceNotificationOptions.EventClass.KEYEVENT)) {
             subscriptionRegistry.publish(
-                    channel("__keyevent@" + dbIndex + "__:", event.getBytes(StandardCharsets.UTF_8)),
+                    channel("__keyevent@" + dbIndex + "__:", event.eventName().getBytes(StandardCharsets.UTF_8)),
                     key);
         }
     }
@@ -103,7 +104,7 @@ public class RedisBase {
         //Otherwise a DBSIZE/KEYS sweep would drop the key silently and a later
         //EXEC could no longer detect that the watched key had expired.
         for (Slice key : outdated) {
-            keyValueStorage.delete(key);
+            keyValueStorage.deleteExpired(key);
         }
         return result;
     }

--- a/src/main/java/com/github/fppt/jedismock/storage/RedisBase.java
+++ b/src/main/java/com/github/fppt/jedismock/storage/RedisBase.java
@@ -11,6 +11,7 @@ import com.github.fppt.jedismock.datastructures.RMString;
 import com.github.fppt.jedismock.datastructures.RMZSet;
 import com.github.fppt.jedismock.datastructures.Slice;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.util.Collections;
 import java.util.HashMap;
@@ -26,20 +27,60 @@ import java.util.function.Supplier;
 public class RedisBase {
     private final Supplier<Clock> clockSupplier;
     private final RedisConfiguration configuration;
+    private final SubscriptionRegistry subscriptionRegistry;
+    private final int dbIndex;
     private final Map<Slice, Set<OperationExecutorState>> watchedKeys = new HashMap<>();
     private final Map<String, String> cachedLuaScripts = new HashMap<>();
     private final ExpiringKeyValueStorage keyValueStorage;
 
     public RedisBase(Supplier<Clock> clockSupplier) {
-        this(clockSupplier, new RedisConfiguration());
+        this(clockSupplier, new RedisConfiguration(), new SubscriptionRegistry(), 0);
     }
 
-    public RedisBase(Supplier<Clock> clockSupplier, RedisConfiguration configuration) {
+    public RedisBase(Supplier<Clock> clockSupplier, RedisConfiguration configuration,
+                     SubscriptionRegistry subscriptionRegistry, int dbIndex) {
         this.clockSupplier = Objects.requireNonNull(clockSupplier);
         this.configuration = Objects.requireNonNull(configuration);
+        this.subscriptionRegistry = Objects.requireNonNull(subscriptionRegistry);
+        this.dbIndex = dbIndex;
         this.keyValueStorage = new ExpiringKeyValueStorage(clockSupplier, key -> watchedKeys
                 .getOrDefault(key, Collections.emptySet())
                 .forEach(OperationExecutorState::watchedKeyIsAffected));
+    }
+
+    /**
+     * Publishes a keyspace notification for an event on a key of this
+     * database, exactly like real Redis's {@code notifyKeyspaceEvent()}:
+     * nothing is sent unless the event's class is enabled by
+     * {@code notify-keyspace-events}, and the enabled channel families each
+     * get their message — {@code __keyspace@<db>__:<key> -> <event>} and/or
+     * {@code __keyevent@<db>__:<event> -> <key>}. Only call while holding
+     * {@link OperationExecutorState#lock()} (all operations do).
+     */
+    public void notifyKeyspaceEvent(KeyspaceNotificationOptions.EventClass eventClass, String event, Slice key) {
+        KeyspaceNotificationOptions options = configuration.getKeyspaceNotificationOptions();
+        if (!options.isEnabled(eventClass)) {
+            return;
+        }
+        if (options.isEnabled(KeyspaceNotificationOptions.EventClass.KEYSPACE)) {
+            subscriptionRegistry.publish(
+                    channel("__keyspace@" + dbIndex + "__:", key.data()),
+                    Slice.create(event));
+        }
+        if (options.isEnabled(KeyspaceNotificationOptions.EventClass.KEYEVENT)) {
+            subscriptionRegistry.publish(
+                    channel("__keyevent@" + dbIndex + "__:", event.getBytes(StandardCharsets.UTF_8)),
+                    key);
+        }
+    }
+
+    /** Keys are binary-safe, so the channel name is built from bytes, not strings. */
+    private static Slice channel(String prefix, byte[] suffix) {
+        byte[] prefixBytes = prefix.getBytes(StandardCharsets.UTF_8);
+        byte[] channel = new byte[prefixBytes.length + suffix.length];
+        System.arraycopy(prefixBytes, 0, channel, 0, prefixBytes.length);
+        System.arraycopy(suffix, 0, channel, prefixBytes.length, suffix.length);
+        return Slice.create(channel);
     }
 
     public Clock getClock() {

--- a/src/main/java/com/github/fppt/jedismock/storage/RedisConfiguration.java
+++ b/src/main/java/com/github/fppt/jedismock/storage/RedisConfiguration.java
@@ -30,6 +30,7 @@ public final class RedisConfiguration {
 
     private final Map<String, String> values = new HashMap<>();
     private long protoMaxBulkLen = DEFAULT_PROTO_MAX_BULK_LEN;
+    private KeyspaceNotificationOptions keyspaceNotificationOptions = KeyspaceNotificationOptions.DISABLED;
 
     public void set(String key, String value) {
         values.put(key.toLowerCase(Locale.ROOT), value);
@@ -60,5 +61,17 @@ public final class RedisConfiguration {
      */
     public void setProtoMaxBulkLen(long protoMaxBulkLen) {
         this.protoMaxBulkLen = Math.min(protoMaxBulkLen, Integer.MAX_VALUE);
+    }
+
+    /**
+     * @return the parsed {@code notify-keyspace-events} value; disabled by
+     * default, matching real Redis.
+     */
+    public KeyspaceNotificationOptions getKeyspaceNotificationOptions() {
+        return keyspaceNotificationOptions;
+    }
+
+    public void setKeyspaceNotificationOptions(KeyspaceNotificationOptions keyspaceNotificationOptions) {
+        this.keyspaceNotificationOptions = keyspaceNotificationOptions;
     }
 }

--- a/src/main/java/com/github/fppt/jedismock/storage/SubscriptionRegistry.java
+++ b/src/main/java/com/github/fppt/jedismock/storage/SubscriptionRegistry.java
@@ -3,6 +3,7 @@ package com.github.fppt.jedismock.storage;
 import com.github.fppt.jedismock.RedisClient;
 import com.github.fppt.jedismock.Utils;
 import com.github.fppt.jedismock.datastructures.Slice;
+import com.github.fppt.jedismock.server.Response;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -129,6 +130,32 @@ public class SubscriptionRegistry {
 
     public List<Slice> getPSubscriptions(RedisClient client) {
         return getSubscriptions(client, psubscribers);
+    }
+
+    /**
+     * Delivers a message to every channel subscriber and every client whose
+     * pattern matches the channel — the delivery logic of {@code PUBLISH},
+     * shared with server-initiated messages such as keyspace notifications.
+     * Only call while holding {@link OperationExecutorState#lock()}: delivery
+     * under the lock is what preserves Redis's ordering guarantee between a
+     * subscribe acknowledgement and the first message (see issue #768).
+     *
+     * @return the number of clients the message was delivered to
+     */
+    public int publish(Slice channel, Slice message) {
+        Set<RedisClient> channelSubscribers = getSubscribers(channel);
+        for (RedisClient subscriber : channelSubscribers) {
+            subscriber.sendResponse(Response.publishedMessage(channel, message), "contacting subscriber");
+        }
+        int deliveries = channelSubscribers.size();
+        for (Map.Entry<Slice, Set<RedisClient>> patternSubscribers : getPsubscribers(channel).entrySet()) {
+            Slice pattern = patternSubscribers.getKey();
+            for (RedisClient psubscriber : patternSubscribers.getValue()) {
+                psubscriber.sendResponse(Response.publishedPMessage(pattern, channel, message), "contacting subscriber");
+            }
+            deliveries += patternSubscribers.getValue().size();
+        }
+        return deliveries;
     }
 
     /**

--- a/src/main/java/com/github/fppt/jedismock/storage/SubscriptionRegistry.java
+++ b/src/main/java/com/github/fppt/jedismock/storage/SubscriptionRegistry.java
@@ -20,12 +20,14 @@ import java.util.Set;
  * cross database boundaries, and clearing a database (FLUSHDB/FLUSHALL)
  * does not affect subscriptions. This registry is therefore owned by the
  * server (like {@link RedisConfiguration}) rather than by a per-database
- * {@link RedisBase}. Shared by every client of the same server; only
- * mutate it while holding {@link OperationExecutorState#lock()}.
+ * {@link RedisBase}, and shared by every client of that server.
  * <p>
- * Guarded by its own monitor rather than by the shared data lock, because a
- * disconnecting client has to deregister itself and must never wait behind a
- * long-running Lua script that holds that lock.
+ * Thread safety is provided by this class itself: every method below is
+ * synchronized on the registry, so callers need no external lock. In
+ * particular it is deliberately <em>not</em> guarded by the shared data lock
+ * ({@link OperationExecutorState#lock()}), because a disconnecting client has
+ * to deregister itself and must never wait behind a long-running Lua script
+ * that holds that lock.
  * <p>
  * <b>Lock ordering.</b> Commands acquire the data lock first and this monitor
  * second (a pub/sub command runs inside {@code MockExecutor}'s synchronized

--- a/src/main/java/com/github/fppt/jedismock/storage/SubscriptionRegistry.java
+++ b/src/main/java/com/github/fppt/jedismock/storage/SubscriptionRegistry.java
@@ -22,6 +22,19 @@ import java.util.Set;
  * server (like {@link RedisConfiguration}) rather than by a per-database
  * {@link RedisBase}. Shared by every client of the same server; only
  * mutate it while holding {@link OperationExecutorState#lock()}.
+ * <p>
+ * Guarded by its own monitor rather than by the shared data lock, because a
+ * disconnecting client has to deregister itself and must never wait behind a
+ * long-running Lua script that holds that lock.
+ * <p>
+ * <b>Lock ordering.</b> Commands acquire the data lock first and this monitor
+ * second (a pub/sub command runs inside {@code MockExecutor}'s synchronized
+ * block and calls the methods below); nothing acquires them the other way
+ * round, so the two cannot deadlock. To keep that true, the synchronized
+ * methods here must never call out to anything that can take the data lock,
+ * {@code wait()} on it, or write to a socket — which is why {@link #publish}
+ * is not synchronized: it snapshots through the copying accessors and only
+ * then performs I/O.
  */
 public class SubscriptionRegistry {
     private final Map<Slice, Set<RedisClient>> subscribers = new HashMap<>();
@@ -32,7 +45,7 @@ public class SubscriptionRegistry {
      * so that callers can maintain the running count for the per-argument
      * acknowledgements without rescanning the registry.
      */
-    public boolean addSubscriber(Slice channel, RedisClient client) {
+    public synchronized boolean addSubscriber(Slice channel, RedisClient client) {
         return subscribers.computeIfAbsent(channel, c -> new HashSet<>()).add(client);
     }
 
@@ -41,21 +54,21 @@ public class SubscriptionRegistry {
      * so that callers can maintain the running count for the per-argument
      * acknowledgements without rescanning the registry.
      */
-    public boolean subscribeByPattern(Slice pattern, RedisClient client) {
+    public synchronized boolean subscribeByPattern(Slice pattern, RedisClient client) {
         return psubscribers.computeIfAbsent(pattern, p -> new HashSet<>()).add(client);
     }
 
     /**
      * @return whether the client was actually subscribed to the channel.
      */
-    public boolean removeSubscriber(Slice channel, RedisClient client) {
+    public synchronized boolean removeSubscriber(Slice channel, RedisClient client) {
         return removeSubscriber(channel, client, subscribers);
     }
 
     /**
      * @return whether the client was actually subscribed to the pattern.
      */
-    public boolean removePSubscriber(Slice channel, RedisClient client) {
+    public synchronized boolean removePSubscriber(Slice channel, RedisClient client) {
         return removeSubscriber(channel, client, psubscribers);
     }
 
@@ -71,7 +84,7 @@ public class SubscriptionRegistry {
         return removed;
     }
 
-    public Set<RedisClient> getSubscribers(Slice channel) {
+    public synchronized Set<RedisClient> getSubscribers(Slice channel) {
         Set<RedisClient> subs = new HashSet<>();
         if (subscribers.containsKey(channel)) {
             subs.addAll(subscribers.get(channel));
@@ -79,7 +92,7 @@ public class SubscriptionRegistry {
         return subs;
     }
 
-    public int getSubscribersCount(Slice channel) {
+    public synchronized int getSubscribersCount(Slice channel) {
         return subscribers.getOrDefault(channel, Collections.emptySet()).size();
     }
 
@@ -88,11 +101,11 @@ public class SubscriptionRegistry {
      * the client — the count Redis reports in every (p)subscribe and
      * (p)unsubscribe acknowledgement.
      */
-    public int getSubscriptionsCount(RedisClient client) {
+    public synchronized int getSubscriptionsCount(RedisClient client) {
         return getSubscriptions(client).size() + getPSubscriptions(client).size();
     }
 
-    public Map<Slice, Set<RedisClient>> getPsubscribers(Slice channel) {
+    public synchronized Map<Slice, Set<RedisClient>> getPsubscribers(Slice channel) {
         Map<Slice, Set<RedisClient>> matchingPatterns = new HashMap<>();
         String channelStr = channel.toString();
         for (Map.Entry<Slice, Set<RedisClient>> patternSubscribedClients : psubscribers.entrySet()) {
@@ -115,20 +128,20 @@ public class SubscriptionRegistry {
         return Utils.createRegexFromGlob(patternStr);
     }
 
-    public int getNumpat() {
+    public synchronized int getNumpat() {
         return psubscribers.size();
     }
 
-    public Set<Slice> getChannels() {
+    public synchronized Set<Slice> getChannels() {
         //Defensive copy: keySet() is a live view backed by the internal map
         return new HashSet<>(subscribers.keySet());
     }
 
-    public List<Slice> getSubscriptions(RedisClient client) {
+    public synchronized List<Slice> getSubscriptions(RedisClient client) {
         return getSubscriptions(client, subscribers);
     }
 
-    public List<Slice> getPSubscriptions(RedisClient client) {
+    public synchronized List<Slice> getPSubscriptions(RedisClient client) {
         return getSubscriptions(client, psubscribers);
     }
 
@@ -139,6 +152,10 @@ public class SubscriptionRegistry {
      * Only call while holding {@link OperationExecutorState#lock()}: delivery
      * under the lock is what preserves Redis's ordering guarantee between a
      * subscribe acknowledgement and the first message (see issue #768).
+     * <p>
+     * Deliberately not synchronized on this registry: it reads the subscriber
+     * sets through the accessors above (which copy them) and then writes to
+     * sockets, so a slow client cannot block another client's disconnect.
      *
      * @return the number of clients the message was delivered to
      */
@@ -163,7 +180,7 @@ public class SubscriptionRegistry {
      * the client disconnects: like in real Redis, a dead connection must not
      * linger in the pub/sub registries.
      */
-    public void removeClient(RedisClient client) {
+    public synchronized void removeClient(RedisClient client) {
         removeClient(client, subscribers);
         removeClient(client, psubscribers);
     }

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/connection/ClientReplyTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/connection/ClientReplyTest.java
@@ -1,0 +1,111 @@
+package com.github.fppt.jedismock.comparisontests.connection;
+
+import com.github.fppt.jedismock.comparisontests.ComparisonBase;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.Jedis;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * CLIENT REPLY ON/OFF/SKIP semantics. Suppression applies to command replies
+ * (including error replies and the +OK of OFF/SKIP themselves) but never to
+ * pub/sub pushes such as subscribe acknowledgements. Asserted over a raw
+ * socket because suppressed replies are invisible to a request/response
+ * client, and because the interesting property is exactly which bytes arrive.
+ */
+@ExtendWith(ComparisonBase.class)
+public class ClientReplyTest {
+
+    static class RawClient implements AutoCloseable {
+        private final Socket socket;
+        private final OutputStream out;
+        private final DataInputStream in;
+
+        RawClient(HostAndPort hostAndPort) throws IOException {
+            socket = new Socket(hostAndPort.getHost(), hostAndPort.getPort());
+            socket.setSoTimeout(5000);
+            out = socket.getOutputStream();
+            in = new DataInputStream(socket.getInputStream());
+        }
+
+        void send(String... args) throws IOException {
+            StringBuilder command = new StringBuilder("*").append(args.length).append("\r\n");
+            for (String arg : args) {
+                command.append('$').append(arg.getBytes(StandardCharsets.UTF_8).length).append("\r\n")
+                        .append(arg).append("\r\n");
+            }
+            out.write(command.toString().getBytes(StandardCharsets.UTF_8));
+            out.flush();
+        }
+
+        /**
+         * Reads exactly as many bytes as the expected replies occupy: anything
+         * suppressed by CLIENT REPLY simply never arrives, so the next reply's
+         * bytes follow immediately.
+         */
+        String read(int length) throws IOException {
+            byte[] buffer = new byte[length];
+            in.readFully(buffer);
+            return new String(buffer, StandardCharsets.UTF_8);
+        }
+
+        @Override
+        public void close() throws Exception {
+            socket.close();
+        }
+    }
+
+    @TestTemplate
+    public void offSuppressesRepliesIncludingErrorsUntilOn(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (RawClient client = new RawClient(hostAndPort)) {
+            client.send("CLIENT", "REPLY", "OFF");        //+OK suppressed
+            client.send("SET", "reply_key", "v");         //+OK suppressed
+            client.send("INCR", "reply_key");             //-ERR suppressed
+            client.send("CLIENT", "REPLY", "ON");         //replies +OK
+            client.send("ECHO", "fin");
+            String expected = "+OK\r\n$3\r\nfin\r\n";
+            assertThat(client.read(expected.length())).isEqualTo(expected);
+        }
+    }
+
+    @TestTemplate
+    public void skipSuppressesExactlyTheNextReply(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (RawClient client = new RawClient(hostAndPort)) {
+            client.send("CLIENT", "REPLY", "SKIP");       //+OK suppressed
+            client.send("SET", "reply_key", "v");         //the "next" reply: suppressed
+            client.send("ECHO", "one");                   //replies again
+            String expected = "$3\r\none\r\n";
+            assertThat(client.read(expected.length())).isEqualTo(expected);
+        }
+    }
+
+    @TestTemplate
+    public void skipIsANoOpWhileRepliesAreOff(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (RawClient client = new RawClient(hostAndPort)) {
+            client.send("CLIENT", "REPLY", "OFF");
+            client.send("CLIENT", "REPLY", "SKIP");       //no-op in OFF mode
+            client.send("CLIENT", "REPLY", "ON");         //replies +OK, not skipped
+            client.send("ECHO", "x");
+            String expected = "+OK\r\n$1\r\nx\r\n";
+            assertThat(client.read(expected.length())).isEqualTo(expected);
+        }
+    }
+
+    @TestTemplate
+    public void subscribeAcknowledgementsBypassSuppression(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (RawClient client = new RawClient(hostAndPort)) {
+            client.send("CLIENT", "REPLY", "OFF");        //+OK suppressed
+            client.send("SUBSCRIBE", "reply_channel");    //the ack is a push, not a reply
+            String expected = "*3\r\n$9\r\nsubscribe\r\n$13\r\nreply_channel\r\n:1\r\n";
+            assertThat(client.read(expected.length())).isEqualTo(expected);
+        }
+    }
+}

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/connection/ConnectionOperationsTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/connection/ConnectionOperationsTest.java
@@ -5,9 +5,12 @@ import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.Jedis;
+import redis.clients.jedis.Protocol;
+import redis.clients.jedis.exceptions.JedisDataException;
 import redis.clients.jedis.util.SafeEncoder;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 
 @ExtendWith(ComparisonBase.class)
@@ -39,5 +42,23 @@ public class ConnectionOperationsTest {
         assertThat(jedis.clientGetname()).isNull();
         assertThat(jedis.clientSetname("P.Myo")).isEqualTo("OK");
         assertThat(jedis.clientGetname()).isEqualTo("P.Myo");
+    }
+
+    @TestTemplate
+    public void clientSubcommandsRejectAWrongNumberOfArguments(Jedis jedis) {
+        assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.CLIENT, "SETNAME"))
+                .isInstanceOf(JedisDataException.class)
+                .hasMessage("ERR wrong number of arguments for 'client|setname' command");
+        assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.CLIENT, "SETNAME", "a", "b"))
+                .isInstanceOf(JedisDataException.class)
+                .hasMessage("ERR wrong number of arguments for 'client|setname' command");
+        assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.CLIENT, "GETNAME", "extra"))
+                .isInstanceOf(JedisDataException.class)
+                .hasMessage("ERR wrong number of arguments for 'client|getname' command");
+        //A rejected SETNAME leaves the previous name untouched
+        jedis.clientSetname("kept");
+        assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.CLIENT, "SETNAME"))
+                .isInstanceOf(JedisDataException.class);
+        assertThat(jedis.clientGetname()).isEqualTo("kept");
     }
 }

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/notifications/GenericKeyspaceNotificationsTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/notifications/GenericKeyspaceNotificationsTest.java
@@ -1,0 +1,301 @@
+package com.github.fppt.jedismock.comparisontests.notifications;
+
+import com.github.fppt.jedismock.comparisontests.ComparisonBase;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPubSub;
+import redis.clients.jedis.params.SetParams;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Keyspace notifications for the generic ({@code g}) and expired ({@code x})
+ * event classes: which commands publish which event, on which of the two
+ * channel families, and for which database.
+ * <p>
+ * Note on {@code EXPIRE} with a time in the past: Redis deletes the key and
+ * publishes a generic {@code del}, whereas Valkey publishes {@code expired}.
+ * These tests follow Redis, matching the container they run against.
+ */
+@ExtendWith(ComparisonBase.class)
+public class GenericKeyspaceNotificationsTest {
+
+    private static final String PARAM = "notify-keyspace-events";
+
+    static class NotificationCollector implements AutoCloseable {
+        private final Jedis client;
+        private final BlockingQueue<String> events = new LinkedBlockingQueue<>();
+        private final JedisPubSub subscriber;
+        private final ExecutorService service = Executors.newSingleThreadExecutor();
+        private final Future<?> future;
+
+        NotificationCollector(HostAndPort hostAndPort) {
+            client = new Jedis(hostAndPort.getHost(), hostAndPort.getPort());
+            subscriber = new JedisPubSub() {
+                @Override
+                public void onPMessage(String pattern, String channel, String message) {
+                    events.add(channel + " -> " + message);
+                }
+            };
+            future = service.submit(() -> client.psubscribe(subscriber, "__key*@*__:*"));
+        }
+
+        /** Waits for exactly {@code count} notifications and returns them in arrival order. */
+        List<String> next(int count) throws InterruptedException {
+            List<String> received = new ArrayList<>();
+            for (int i = 0; i < count; i++) {
+                String event = events.poll(10, TimeUnit.SECONDS);
+                assertThat(event).as("notification %d of %d (got %s)", i + 1, count, received).isNotNull();
+                received.add(event);
+            }
+            return received;
+        }
+
+        void assertNoFurtherNotifications() throws InterruptedException {
+            assertThat(events.poll(300, TimeUnit.MILLISECONDS)).isNull();
+        }
+
+        @Override
+        public void close() throws Exception {
+            try {
+                subscriber.punsubscribe();
+                future.get(5, TimeUnit.SECONDS);
+            } catch (TimeoutException e) {
+                //Fall through to the forced disconnect below.
+            } finally {
+                service.shutdownNow();
+                client.disconnect();
+                client.close();
+            }
+        }
+    }
+
+    private static NotificationCollector collectorFor(Jedis jedis, HostAndPort hostAndPort, String flags) {
+        jedis.flushAll();
+        jedis.configSet(PARAM, flags);
+        NotificationCollector collector = new NotificationCollector(hostAndPort);
+        Awaitility.await().until(() -> jedis.pubsubNumPat() > 0);
+        return collector;
+    }
+
+    @TestTemplate
+    public void generalEventsTest(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "KEg")) {
+            jedis.set("foo", "bar");   //string class: silent under 'g'
+            jedis.expire("foo", 100);
+            jedis.del("foo");
+            assertThat(events.next(4)).containsExactly(
+                    "__keyspace@0__:foo -> expire",
+                    "__keyevent@0__:expire -> foo",
+                    "__keyspace@0__:foo -> del",
+                    "__keyevent@0__:del -> foo");
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    @TestTemplate
+    public void keyspaceChannelOnly(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "Kg")) {
+            jedis.set("foo", "bar");
+            jedis.del("foo");
+            assertThat(events.next(1)).containsExactly("__keyspace@0__:foo -> del");
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    @TestTemplate
+    public void keyeventChannelOnly(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "Eg")) {
+            jedis.set("foo", "bar");
+            jedis.del("foo");
+            assertThat(events.next(1)).containsExactly("__keyevent@0__:del -> foo");
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    @TestTemplate
+    public void nothingIsPublishedWhileDisabled(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "")) {
+            jedis.set("foo", "bar");
+            jedis.expire("foo", 100);
+            jedis.del("foo");
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    @TestTemplate
+    public void deleteEventsForDelUnlinkAndGetdel(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "Eg")) {
+            jedis.mset("d1", "v", "d2", "v", "d3", "v");
+            jedis.del("d1");
+            jedis.unlink("d2");
+            jedis.getDel("d3");
+            //UNLINK publishes 'del' as well, not 'unlink'
+            assertThat(events.next(3)).containsExactly(
+                    "__keyevent@0__:del -> d1",
+                    "__keyevent@0__:del -> d2",
+                    "__keyevent@0__:del -> d3");
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    @TestTemplate
+    public void deleteEventPerKeyOfMultiKeyDelete(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "Eg")) {
+            jedis.mset("m1", "v", "m2", "v");
+            //Only existing keys are reported
+            jedis.del("m1", "missing", "m2");
+            assertThat(events.next(2)).containsExactly(
+                    "__keyevent@0__:del -> m1",
+                    "__keyevent@0__:del -> m2");
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    @TestTemplate
+    public void expirationCommandsPublishExpire(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "Eg")) {
+            jedis.mset("e1", "v", "e2", "v", "e3", "v", "e4", "v");
+            jedis.expire("e1", 100);
+            jedis.pexpire("e2", 100_000);
+            jedis.expireAt("e3", System.currentTimeMillis() / 1000 + 100);
+            jedis.pexpireAt("e4", System.currentTimeMillis() + 100_000);
+            assertThat(events.next(4)).containsExactly(
+                    "__keyevent@0__:expire -> e1",
+                    "__keyevent@0__:expire -> e2",
+                    "__keyevent@0__:expire -> e3",
+                    "__keyevent@0__:expire -> e4");
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    @TestTemplate
+    public void expirationInThePastPublishesDelete(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "Egx")) {
+            jedis.mset("p1", "v", "p2", "v");
+            jedis.expire("p1", -1);
+            jedis.pexpireAt("p2", 1);
+            //The key is deleted straight away: a 'del', not an 'expired'
+            assertThat(events.next(2)).containsExactly(
+                    "__keyevent@0__:del -> p1",
+                    "__keyevent@0__:del -> p2");
+            events.assertNoFurtherNotifications();
+            assertThat(jedis.exists("p1")).isFalse();
+        }
+    }
+
+    @TestTemplate
+    public void noEventForExpirationOfMissingKey(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "Egx")) {
+            jedis.expire("nosuchkey", 100);
+            jedis.expire("nosuchkey", -1);
+            jedis.del("nosuchkey");
+            jedis.persist("nosuchkey");
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    @TestTemplate
+    public void persistPublishesPersistOnlyWhenTtlIsRemoved(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "Eg")) {
+            jedis.set("pers", "v", SetParams.setParams().ex(100));
+            assertThat(events.next(1)).containsExactly("__keyevent@0__:expire -> pers");
+            jedis.persist("pers");
+            assertThat(events.next(1)).containsExactly("__keyevent@0__:persist -> pers");
+            //No TTL left to remove: silent
+            jedis.persist("pers");
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    //GETEX is not implemented by the mock at all, so its expire/persist events
+    //are out of scope here; add a case once the command itself is supported.
+
+    @TestTemplate
+    public void settingWithExpirationPublishesGenericExpire(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "Eg")) {
+            //The accompanying 'set' belongs to the string class, so under 'g'
+            //only the expiration is reported
+            jedis.set("s1", "v", SetParams.setParams().ex(100));
+            jedis.setex("s2", 100, "v");
+            jedis.psetex("s3", 100_000, "v");
+            assertThat(events.next(3)).containsExactly(
+                    "__keyevent@0__:expire -> s1",
+                    "__keyevent@0__:expire -> s2",
+                    "__keyevent@0__:expire -> s3");
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    @TestTemplate
+    public void renamePublishesRenameFromAndRenameTo(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "KEg")) {
+            jedis.set("old", "v");
+            jedis.rename("old", "new");
+            assertThat(events.next(4)).containsExactly(
+                    "__keyspace@0__:old -> rename_from",
+                    "__keyevent@0__:rename_from -> old",
+                    "__keyspace@0__:new -> rename_to",
+                    "__keyevent@0__:rename_to -> new");
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    @TestTemplate
+    public void movePublishesMoveFromAndMoveToOfDestinationDatabase(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "KEg")) {
+            jedis.set("mv", "v");
+            jedis.move("mv", 1);
+            //move_to is published on the destination database's channels
+            assertThat(events.next(4)).containsExactly(
+                    "__keyspace@0__:mv -> move_from",
+                    "__keyevent@0__:move_from -> mv",
+                    "__keyspace@1__:mv -> move_to",
+                    "__keyevent@1__:move_to -> mv");
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    @TestTemplate
+    public void copyPublishesCopyToForDestinationOnly(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "Eg")) {
+            jedis.set("src", "v");
+            jedis.copy("src", "dst", false);
+            assertThat(events.next(1)).containsExactly("__keyevent@0__:copy_to -> dst");
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    @TestTemplate
+    public void expiredEventOnAccessOfAnExpiredKey(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "Ex")) {
+            jedis.psetex("gone", 50, "v");
+            Awaitility.await().until(() -> !jedis.exists("gone"));
+            assertThat(events.next(1)).containsExactly("__keyevent@0__:expired -> gone");
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    @TestTemplate
+    public void expiredEventIsPublishedOnceForAKeySweptByKeys(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "Ex")) {
+            jedis.psetex("swept", 50, "v");
+            Awaitility.await().until(() -> jedis.keys("swept").isEmpty());
+            assertThat(events.next(1)).containsExactly("__keyevent@0__:expired -> swept");
+            events.assertNoFurtherNotifications();
+        }
+    }
+}

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/server/NotifyKeyspaceEventsConfigTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/server/NotifyKeyspaceEventsConfigTest.java
@@ -1,0 +1,64 @@
+package com.github.fppt.jedismock.comparisontests.server;
+
+import com.github.fppt.jedismock.comparisontests.ComparisonBase;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.exceptions.JedisDataException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * {@code notify-keyspace-events} is not a verbatim string parameter: Redis
+ * parses it into a set of event-class flags and {@code CONFIG GET} reports
+ * the canonical form (the {@code A} alias collapses the classes it covers,
+ * and the characters are emitted in a fixed order).
+ */
+@ExtendWith(ComparisonBase.class)
+public class NotifyKeyspaceEventsConfigTest {
+
+    private static final String PARAM = "notify-keyspace-events";
+
+    @TestTemplate
+    public void flagsAreNormalizedOnRead(Jedis jedis) {
+        String[][] inputToCanonical = {
+                {"KA", "AK"},
+                {"EA", "AE"},
+                {"KEA", "AKE"},
+                {"AKE", "AKE"},
+                {"A", "A"},
+                {"gKE", "gKE"},
+                {"$lshzxeKE", "$lshzxeKE"},
+                {"En", "nE"},
+                {"Kn", "nK"},
+                {"nKE", "nKE"},
+                {"mKE", "KEm"},
+                {"dKE", "dKE"},
+                {"Egx", "gxE"},
+                {"K", "K"},
+                {"", ""},
+        };
+        for (String[] testCase : inputToCanonical) {
+            assertThat(jedis.configSet(PARAM, testCase[0])).isEqualTo("OK");
+            assertThat(jedis.configGet(PARAM))
+                    .as("canonical form of '%s'", testCase[0])
+                    .containsEntry(PARAM, testCase[1]);
+        }
+    }
+
+    @TestTemplate
+    public void invalidEventClassCharacterIsRejected(Jedis jedis) {
+        jedis.configSet(PARAM, "gKE");
+        for (String invalid : new String[]{"Q", "Egq", "K E"}) {
+            assertThatThrownBy(() -> jedis.configSet(PARAM, invalid))
+                    .as("flags '%s'", invalid)
+                    .isInstanceOf(JedisDataException.class)
+                    .hasMessage("ERR CONFIG SET failed (possibly related to argument '" + PARAM
+                            + "') - Invalid event class character. Use 'Ag$lshzxeKEtmdn'.");
+        }
+        //A rejected SET leaves the previous value in place
+        assertThat(jedis.configGet(PARAM)).containsEntry(PARAM, "gKE");
+        jedis.configSet(PARAM, "");
+    }
+}


### PR DESCRIPTION
Implements keyspace notifications for the **generic** (`g`) and **expired** (`x`) event classes, plus the `notify-keyspace-events` configuration parameter and `CLIENT REPLY`.

Closes #809 — verified end to end against the reporter's reproducer ([ComputerDaddyGuy/jedismock-timeout](https://github.com/ComputerDaddyGuy/jedismock-timeout)): with this branch the Spring Boot app starts and `@EnableRedisIndexedHttpSession` works. Partially addresses #406 (type-specific classes still to come).

## Why #809 needed two separate things

Tracing the reproducer's traffic showed Spring Session doing exactly this:

```
config GET notify-keyspace-events
config SET notify-keyspace-events Egx
psubscribe spring:session:event:0:created:*
subscribe __keyevent@0__:del __keyevent@0__:expired
```

The `IllegalStateException: Subscription registration timeout exceeded` came from the subscribe acknowledgements, and was already fixed by #810. What remained was that nothing ever *published* to those two channels, so the listener container registered but no session ever expired. This PR supplies the missing half.

## Configuration

`notify-keyspace-events` is no longer stored verbatim — it is parsed into a set of event classes, validated, and reported back in canonical form, matching Redis:

| `CONFIG SET` | `CONFIG GET` returns |
| --- | --- |
| `KA` | `AK` |
| `EA` | `AE` |
| `KEA` | `AKE` |
| `Egx` | `gxE` |
| `mKE` | `KEm` |

An unknown flag character is rejected with Redis's own message (`Invalid event class character. Use 'Ag$lshzxeKEtmdn'.`) and leaves the previous value in place.

`CLIENT REPLY ON/OFF/SKIP` is implemented too (previously a no-op returning `+OK`, which desynchronised clients). Suppression covers command replies including errors, but never pub/sub pushes — subscribe acknowledgements and published messages still arrive while replies are silenced.

## Events

Derived by probing `redis:7.4-alpine` rather than from the docs, which turned up several surprises (marked ⚠):

| Command | Event(s) |
| --- | --- |
| `DEL`, `GETDEL` | `del` |
| `UNLINK` | `del` ⚠ (not `unlink`) |
| `EXPIRE`/`PEXPIRE`/`EXPIREAT`/`PEXPIREAT`, future | `expire` |
| …with a time in the past | `del` ⚠ + the key is deleted immediately |
| `PERSIST` | `persist`, only when a TTL was actually removed |
| `RENAME` | `rename_from` on the old key, `rename_to` on the new |
| `MOVE` | `move_from` on the source db, `move_to` **on the destination db's channels** ⚠ |
| `COPY` | `copy_to`, destination only |
| `SET … EX`, `SETEX`, `PSETEX` | `set` (string class) **+** `expire` (generic) ⚠ |
| passive expiry on access | `expired` |

`MOVE` is worth noting: `move_to` is published on `__keyspace@<destination-db>__`, which only works because #810 made pub/sub server-wide.

**Redis vs Valkey divergence.** For an expiration set in the past, Redis 7.4 publishes a generic `del` while Valkey 8.1.9 publishes `expired` (both verified in containers). This follows Redis, since that is what the comparison tests and CI run against; the corresponding backported test stays disabled with a comment explaining it is a version difference rather than a gap.

## Two concurrency fixes (independent of notifications)

Both are the same hazard: *nothing reachable while a runaway Lua script holds the data lock may block on that lock.* They surfaced as a hang in `unit/multi` and were diagnosed from a JVM thread dump.

1. **`Eval` BUSY-gate race (pre-existing).** `ScriptingManager.start()` was called *after* building the Lua environment. That setup is slow the first time (luaj compiles `REDIS_LUA`, cjson, the sandbox), so a command arriving on another connection could observe "no script running", pass the BUSY gate in `MockExecutor`, and then block on the data lock the script was about to take — with no way to ever be answered. `MockExecutor` documents this window as "microsecond-wide"; on a cold `EVAL` it is hundreds of milliseconds. Fixed by marking the script running before the setup, with the setup moved inside the existing `try`/`finally` so `stop()` is still guaranteed.

   ⚠ **Reviewer note:** `lua-time-limit` now measures from before the Lua environment is built, so setup time counts toward the BUSY threshold. Arguably more faithful (real Redis times the whole `EVAL`), but it is a deliberate behaviour change.

2. **Disconnect cleanup no longer takes the data lock** (regression from #810). Deregistering a client's subscriptions on disconnect blocked whenever another connection was running a long script. `SubscriptionRegistry` now guards itself with its own monitor. Lock ordering is documented on the class: commands take the data lock first and the registry second, never the reverse, so the two cannot deadlock; `publish()` is deliberately unsynchronised so it snapshots subscribers and then performs socket I/O holding no registry monitor. This also unblocks `RedisServer.stop()` when a client is mid-command.

## Testing

* **28 new comparison tests** (`GenericKeyspaceNotificationsTest`, `NotifyKeyspaceEventsConfigTest`, `ClientReplyTest`), each verified failing against JedisMock and passing against real Redis before implementation. They assert exact event *sequences*, the keyspace/keyevent channel split, class masking, and cross-database delivery; the `CLIENT REPLY` cases assert raw RESP bytes over a socket, since suppressed replies are invisible to a request/response client.
* **Three upstream TCL tests un-gated and passing**: `general events test`, `expired events (triggered expire)`, `test CONFIG GET/SET of event flags`.
* Full native matrix (14 suites) and the full Java suite green.

## Still out of scope

* Type-specific classes `$ l s h z t` and the `n` (new key) class — #406, next step.
* `expired events (background expire)`: JedisMock expires keys lazily, so a key nobody touches produces no event. Spring Session's cleanup task does touch keys, which is why #809 works regardless; an active-expiry cycle would make this robust.
* `evicted` events (no `maxmemory` model) and `GETEX` (the command itself is unimplemented).
* `TTL`/`PTTL` on an already-expired key does not publish `expired` — the hook is on the value-access path, and extending it to TTL lookups risks spurious events from internal calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
