### PR TITLE
Keyspace type specific events

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 
 Jedis-Mock is an in-memory mock of Redis/Valkey for Java testing, which can also work as a test proxy.
 While being simple to use, it faithfully replicates Redis/Valkey behaviour, with rich and precise support
-for data types, streams, transactions, [Lua scripting](#luascripting) and [cluster mode](#cluster) — effectively making it
-a Redis/Valkey reimplementation in Java.
+for data types, streams, transactions, [Lua scripting](#luascripting), [keyspace notifications](#keyspacenotifications)
+and [cluster mode](#cluster) — effectively making it a Redis/Valkey reimplementation in Java.
 
 Despite its name, it works at the network protocol level and can be used with any Redis client
 (be it [Jedis](https://github.com/redis/jedis), [Lettuce](https://github.com/lettuce-io/lettuce-core), [Redisson](https://github.com/redisson/redisson) or others).
@@ -237,8 +237,71 @@ Only the following parameters are actually honoured by the mock:
 | --- | --- | --- |
 | `lua-time-limit` (alias `busy-reply-threshold`) | how long a Lua script may run before other clients get `-BUSY` (see [Script timeouts](#script-timeouts-busy-and-script-kill)) | `5000` (ms); `0` disables |
 | `proto-max-bulk-len` | largest string a command may build, enforced by `SETRANGE`/`APPEND` (`-ERR string exceeds maximum allowed size`) | `536870912` (512 MB) |
+| `notify-keyspace-events` | which [keyspace notifications](#keyspacenotifications) are published | `""` (disabled) |
 
 `proto-max-bulk-len` is capped at `Integer.MAX_VALUE`, since the mock stores strings as `byte[]` and cannot honour a larger limit. Glob-style patterns in `CONFIG GET` are not supported; each argument is treated as a literal parameter name.
+
+
+## <a name="keyspacenotifications">Keyspace notifications</a>
+
+[Keyspace notifications](https://redis.io/docs/latest/develop/pubsub/keyspace-notifications/) are supported: enable them with `CONFIG SET notify-keyspace-events` and subscribe to the
+`__keyspace@<db>__:<key>` and/or `__keyevent@<db>__:<event>` channels as you would against a real server.
+
+```java
+jedis.configSet("notify-keyspace-events", "KEA");   // all events, both channel families
+
+// in another connection
+jedis.psubscribe(new JedisPubSub() {
+    @Override
+    public void onPMessage(String pattern, String channel, String message) {
+        // __keyspace@0__:mykey -> set
+        // __keyevent@0__:set   -> mykey
+    }
+}, "__key*@0__:*");
+```
+
+The flag string is parsed and validated exactly as Redis does, so `CONFIG GET` reports the canonical
+form (`KA` reads back as `AK`) and an unknown flag character is rejected. Pub/Sub is server-wide, so a
+subscriber on one database receives events for every database.
+
+### Supported event classes
+
+| Flag | Class | Events |
+| --- | --- | --- |
+| `K` | keyspace channel | publishes to `__keyspace@<db>__:<key>` |
+| `E` | keyevent channel | publishes to `__keyevent@<db>__:<event>` |
+| `g` | generic | `del`, `expire`, `persist`, `rename_from`, `rename_to`, `move_from`, `move_to`, `copy_to` |
+| `$` | string | `set`, `append`, `setrange`, `incrby`, `incrbyfloat` |
+| `l` | list | `lpush`, `rpush`, `lpop`, `rpop`, `linsert`, `lset`, `lrem`, `ltrim`, `sortstore` |
+| `s` | set | `sadd`, `srem`, `spop`, `sinterstore`, `sunionstore`, `sdiffstore` |
+| `h` | hash | `hset`, `hdel`, `hincrby`, `hincrbyfloat` |
+| `z` | sorted set | `zadd`, `zincr`, `zrem`, `zremrangebyscore`, `zremrangebyrank`, `zremrangebylex`, `zunionstore`, `zinterstore`, `zdiffstore`, `zrangestore`, `zpopmin`, `zpopmax` |
+| `t` | stream | `xadd`, `xtrim`, `xdel` |
+| `x` | expired | `expired` |
+| `n` | new key | `new` |
+| `A` | alias for `g$lshzxet` (and `d`) — note it does **not** cover `n` or `m` | |
+
+As in Redis, the event name is not always the command name: every flavour of assignment reports `set`,
+`DECR`/`DECRBY` report `incrby`, `ZINCRBY` reports `zincr`, `UNLINK` reports `del`, and emptying a
+container reports the *generic* `del` in addition to the type's own event.
+
+### Current limitations
+
+* **No active expiry.** Keys expire lazily, when something touches them, so a key that nobody reads
+  produces its `expired` event later than a real server would (which expires in the background). Code
+  that periodically scans its keys — Spring Session's cleanup task, for example — works fine.
+* **`e` (evicted) and `m` (key-miss) events are not published.** The mock has no `maxmemory`, so
+  nothing is ever evicted, and key misses are not tracked.
+* **`d` (module) events are not published**, as the mock has no module support.
+* **Stream consumer-group events are absent** (`xgroup-create`, `xgroup-createconsumer`,
+  `xgroup-delconsumer`, `xgroup-destroy`, `xsetid`, `xclaim`) because the mock does not implement the
+  consumer-group commands themselves.
+* **`TTL`/`PTTL` on an already-expired key does not publish `expired`.** The event is published from
+  the value-access path, not from TTL lookups.
+* **An expiration set in the past reports `del`, matching Redis**, whereas Valkey reports `expired`
+  for the same command.
+* Events are published for hash-field expiration commands (`HEXPIRE` and friends) only insofar as
+  they set TTLs; the dedicated `hexpired`/`hpersist` events of newer Redis are not implemented.
 
 
 ## Supported and Missing Operations

--- a/native_tests/linux/tests/unit/pubsub.tcl
+++ b/native_tests/linux/tests/unit/pubsub.tcl
@@ -335,8 +335,6 @@ start_server {tags {"pubsub network"}} {
         $rd1 close
     }
 
-    # Set, zset, hash and stream classes are not implemented yet (issue #406).
-    if 0 {
     test "Keyspace notifications: set events test" {
         r config set notify-keyspace-events Ks
         r del myset
@@ -379,6 +377,8 @@ start_server {tags {"pubsub network"}} {
         $rd1 close
     }
 
+    # The stream class is not implemented yet (issue #406).
+    if 0 {
     test "Keyspace notifications: stream events test" {
         r config set notify-keyspace-events Kt
         r del mystream

--- a/native_tests/linux/tests/unit/pubsub.tcl
+++ b/native_tests/linux/tests/unit/pubsub.tcl
@@ -377,7 +377,11 @@ start_server {tags {"pubsub network"}} {
         $rd1 close
     }
 
-    # The stream class is not implemented yet (issue #406).
+    # Disabled because jedis-mock does not implement the consumer-group
+    # commands this test drives (XGROUP, XREADGROUP, XCLAIM, XAUTOCLAIM), so
+    # their xgroup-* events cannot exist. The stream events for the commands
+    # that *are* implemented (xadd, xtrim, xdel) are covered by
+    # StreamKeyspaceNotificationsTest.
     if 0 {
     test "Keyspace notifications: stream events test" {
         r config set notify-keyspace-events Kt

--- a/native_tests/linux/tests/unit/pubsub.tcl
+++ b/native_tests/linux/tests/unit/pubsub.tcl
@@ -291,8 +291,6 @@ start_server {tags {"pubsub network"}} {
         $rd1 close
     }
 
-    # Needs list-class ('l') events, which are not implemented yet (issue #406).
-    if 0 {
     test "Keyspace notifications: we are able to mask events" {
         r config set notify-keyspace-events KEl
         r del mylist
@@ -304,8 +302,6 @@ start_server {tags {"pubsub network"}} {
         assert_equal "pmessage * __keyspace@${db}__:mylist lpush" [$rd1 read]
         assert_equal "pmessage * __keyevent@${db}__:lpush mylist" [$rd1 read]
         $rd1 close
-    }
-
     }
 
     test "Keyspace notifications: general events test" {
@@ -322,8 +318,6 @@ start_server {tags {"pubsub network"}} {
         $rd1 close
     }
 
-    # Type-specific event classes are not implemented yet (issue #406).
-    if 0 {
     test "Keyspace notifications: list events test" {
         r config set notify-keyspace-events KEl
         r del mylist
@@ -341,6 +335,8 @@ start_server {tags {"pubsub network"}} {
         $rd1 close
     }
 
+    # Set, zset, hash and stream classes are not implemented yet (issue #406).
+    if 0 {
     test "Keyspace notifications: set events test" {
         r config set notify-keyspace-events Ks
         r del myset

--- a/native_tests/linux/tests/unit/pubsub.tcl
+++ b/native_tests/linux/tests/unit/pubsub.tcl
@@ -481,8 +481,6 @@ start_server {tags {"pubsub network"}} {
         assert_equal {AE} [lindex [r config get notify-keyspace-events] 1]
     }
 
-    # The 'n' (new key) event class is not implemented yet (issue #406).
-    if 0 {
     test "Keyspace notifications: new key test" {
         r config set notify-keyspace-events En
         set rd1 [redis_deferring_client]
@@ -494,7 +492,6 @@ start_server {tags {"pubsub network"}} {
         assert_equal "pmessage * __keyevent@${db}__:new foo" [$rd1 read]
         assert_equal "pmessage * __keyevent@${db}__:new bar" [$rd1 read]
         $rd1 close
-    }
     }
 
     test "publish to self inside multi" {

--- a/native_tests/linux/tests/unit/pubsub.tcl
+++ b/native_tests/linux/tests/unit/pubsub.tcl
@@ -259,9 +259,6 @@ start_server {tags {"pubsub network"}} {
 
     ### Keyspace events notification tests
 
-    # These need string-class ('$') events, which are not implemented yet
-    # (issue #406); the generic and expired classes below do work.
-    if 0 {
     test "Keyspace notifications: we receive keyspace notifications" {
         r config set notify-keyspace-events KA
         set rd1 [redis_deferring_client]
@@ -294,6 +291,8 @@ start_server {tags {"pubsub network"}} {
         $rd1 close
     }
 
+    # Needs list-class ('l') events, which are not implemented yet (issue #406).
+    if 0 {
     test "Keyspace notifications: we are able to mask events" {
         r config set notify-keyspace-events KEl
         r del mylist

--- a/src/main/java/com/github/fppt/jedismock/operations/AbstractBPop.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/AbstractBPop.java
@@ -77,7 +77,7 @@ public abstract class AbstractBPop extends AbstractRedisOperation {
         //Remember why the loop ended: we must not re-probe the connection at
         //delivery time. A transient liveness-probe failure right when data has
         //arrived would otherwise drop a legitimate reply and hang the client.
-        boolean connected = true;
+        boolean connected;
         //Register as a FIFO waiter on every key so that, among several clients
         //blocked on the same key, the oldest is served first (matching real
         //Redis). Without this, notifyAll() lets an arbitrary waiter steal the

--- a/src/main/java/com/github/fppt/jedismock/operations/hashes/HDel.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/hashes/HDel.java
@@ -4,6 +4,7 @@ import com.github.fppt.jedismock.operations.AbstractRedisOperation;
 import com.github.fppt.jedismock.operations.RedisCommand;
 import com.github.fppt.jedismock.server.Response;
 import com.github.fppt.jedismock.datastructures.Slice;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.RedisBase;
 
 import java.util.List;
@@ -30,6 +31,14 @@ class HDel extends AbstractRedisOperation {
 
             if (oldValue != null) {
                 ++count;
+            }
+        }
+
+        if (count > 0) {
+            base().notifyKeyspaceEvent(KeyspaceEvent.HDEL, key);
+            //Deleting the last field removes the hash, a generic del
+            if (!base().exists(key)) {
+                base().notifyKeyspaceEvent(KeyspaceEvent.DEL, key);
             }
         }
 

--- a/src/main/java/com/github/fppt/jedismock/operations/hashes/HIncrBy.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/hashes/HIncrBy.java
@@ -4,6 +4,7 @@ import com.github.fppt.jedismock.operations.AbstractRedisOperation;
 import com.github.fppt.jedismock.operations.RedisCommand;
 import com.github.fppt.jedismock.server.Response;
 import com.github.fppt.jedismock.datastructures.Slice;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.RedisBase;
 
 import java.util.List;
@@ -26,10 +27,17 @@ class HIncrBy extends AbstractRedisOperation {
         return Response.integer(numericValue);
     }
 
+    /** The event this increment reports; the float variant overrides it. */
+    KeyspaceEvent incrementEvent() {
+        return KeyspaceEvent.HINCRBY;
+    }
+
     protected Slice response() {
         Slice key1 = params().get(0);
         Slice key2 = params().get(1);
         Slice value = params().get(2);
-        return hsetValue(key1, key2, value);
+        Slice result = hsetValue(key1, key2, value);
+        base().notifyKeyspaceEvent(incrementEvent(), key1);
+        return result;
     }
 }

--- a/src/main/java/com/github/fppt/jedismock/operations/hashes/HIncrByFloat.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/hashes/HIncrByFloat.java
@@ -3,6 +3,7 @@ package com.github.fppt.jedismock.operations.hashes;
 import com.github.fppt.jedismock.operations.RedisCommand;
 import com.github.fppt.jedismock.server.Response;
 import com.github.fppt.jedismock.datastructures.Slice;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.RedisBase;
 
 import java.text.DecimalFormat;
@@ -37,6 +38,12 @@ class HIncrByFloat extends HIncrBy {
         }
     }
 
+    @Override
+    KeyspaceEvent incrementEvent() {
+        return KeyspaceEvent.HINCRBYFLOAT;
+    }
+
+    @Override
     Slice hsetValue(Slice key1, Slice key2, Slice value) {
         double numericValue = convertToDouble(String.valueOf(value));
         Slice foundValue = base().getSlice(key1, key2);
@@ -53,12 +60,6 @@ class HIncrByFloat extends HIncrBy {
         return Response.bulkString(res);
     }
 
-    @Override
-    protected Slice response() {
-        Slice key1 = params().get(0);
-        Slice key2 = params().get(1);
-        Slice value = params().get(2);
-
-        return hsetValue(key1, key2, value);
-    }
+    //response() is inherited: it is identical to HIncrBy's and reports the
+    //event returned by incrementEvent() above.
 }

--- a/src/main/java/com/github/fppt/jedismock/operations/hashes/HSet.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/hashes/HSet.java
@@ -4,6 +4,7 @@ import com.github.fppt.jedismock.operations.AbstractRedisOperation;
 import com.github.fppt.jedismock.operations.RedisCommand;
 import com.github.fppt.jedismock.server.Response;
 import com.github.fppt.jedismock.datastructures.Slice;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.RedisBase;
 
 import java.util.List;
@@ -18,6 +19,14 @@ class HSet extends AbstractRedisOperation {
         Slice foundValue = base().getSlice(key1, key2);
         base().putSlice(key1, key2, value, null);
         return foundValue;
+    }
+
+    /**
+     * @return whether this command writes regardless of the field's presence.
+     * {@code HSETNX} overrides it to false, so that a no-op reports nothing.
+     */
+    boolean writesUnconditionally() {
+        return true;
     }
 
     @Override
@@ -37,6 +46,12 @@ class HSet extends AbstractRedisOperation {
             if (oldValue == null) {
                 count++;
             }
+        }
+
+        //HSET/HMSET always write, so always report; HSETNX only writes when the
+        //field was absent, which is exactly when count > 0
+        if (writesUnconditionally() || count > 0) {
+            base().notifyKeyspaceEvent(KeyspaceEvent.HSET, hash);
         }
 
         return Response.integer(count);

--- a/src/main/java/com/github/fppt/jedismock/operations/hashes/HSetNX.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/hashes/HSetNX.java
@@ -19,4 +19,9 @@ class HSetNX extends HSet {
         }
         return foundValue;
     }
+
+    @Override
+    boolean writesUnconditionally() {
+        return false;
+    }
 }

--- a/src/main/java/com/github/fppt/jedismock/operations/lists/Add.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/lists/Add.java
@@ -4,6 +4,7 @@ import com.github.fppt.jedismock.datastructures.RMList;
 import com.github.fppt.jedismock.operations.AbstractRedisOperation;
 import com.github.fppt.jedismock.server.Response;
 import com.github.fppt.jedismock.datastructures.Slice;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.OperationExecutorState;
 
 import java.util.List;
@@ -17,6 +18,9 @@ abstract class Add extends AbstractRedisOperation {
 
     abstract void addSliceToList(List<Slice> list, Slice slice);
 
+    /** The event this push reports: {@code lpush} or {@code rpush}. */
+    abstract KeyspaceEvent pushEvent();
+
     protected Slice response() {
         Slice key = params().get(0);
         final RMList listDBObj = getListFromBaseOrCreateEmpty(key);
@@ -27,6 +31,8 @@ abstract class Add extends AbstractRedisOperation {
         }
 
         base().putValue(key, listDBObj);
+        //One event per command, however many elements were pushed
+        base().notifyKeyspaceEvent(pushEvent(), key);
 
         //Notify all waiting operations
         lock.notifyAll();

--- a/src/main/java/com/github/fppt/jedismock/operations/lists/LInsert.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/lists/LInsert.java
@@ -4,6 +4,7 @@ import com.github.fppt.jedismock.datastructures.Slice;
 import com.github.fppt.jedismock.operations.AbstractRedisOperation;
 import com.github.fppt.jedismock.operations.RedisCommand;
 import com.github.fppt.jedismock.server.Response;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.RedisBase;
 
 import java.util.Arrays;
@@ -43,6 +44,8 @@ public class LInsert extends AbstractRedisOperation {
 
         int index = direction.equalsIgnoreCase(BEFORE) ? i : i + 1;
         storedElements.add(index, element);
+        base().markKeyModified(key);
+        base().notifyKeyspaceEvent(KeyspaceEvent.LINSERT, key);
         return Response.integer(storedElements.size());
     }
 }

--- a/src/main/java/com/github/fppt/jedismock/operations/lists/LPop.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/lists/LPop.java
@@ -2,6 +2,7 @@ package com.github.fppt.jedismock.operations.lists;
 
 import com.github.fppt.jedismock.datastructures.Slice;
 import com.github.fppt.jedismock.operations.RedisCommand;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.RedisBase;
 
 import java.util.List;
@@ -14,5 +15,10 @@ class LPop extends ListPopper {
 
     Slice popper(List<Slice> list) {
         return list.remove(0);
+    }
+
+    @Override
+    KeyspaceEvent popEvent() {
+        return KeyspaceEvent.LPOP;
     }
 }

--- a/src/main/java/com/github/fppt/jedismock/operations/lists/LPush.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/lists/LPush.java
@@ -1,6 +1,7 @@
 package com.github.fppt.jedismock.operations.lists;
 
 import com.github.fppt.jedismock.operations.RedisCommand;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.OperationExecutorState;
 import com.github.fppt.jedismock.datastructures.Slice;
 
@@ -15,5 +16,10 @@ class LPush extends Add {
     @Override
     void addSliceToList(List<Slice> list, Slice slice) {
         list.add(0, slice);
+    }
+
+    @Override
+    KeyspaceEvent pushEvent() {
+        return KeyspaceEvent.LPUSH;
     }
 }

--- a/src/main/java/com/github/fppt/jedismock/operations/lists/LRem.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/lists/LRem.java
@@ -5,6 +5,7 @@ import com.github.fppt.jedismock.operations.AbstractRedisOperation;
 import com.github.fppt.jedismock.operations.RedisCommand;
 import com.github.fppt.jedismock.server.Response;
 import com.github.fppt.jedismock.datastructures.Slice;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.RedisBase;
 
 import java.util.List;
@@ -49,6 +50,14 @@ class LRem extends AbstractRedisOperation {
             if (isDeletingElement(element, numRemoved)) {
                 iterator.remove();
                 numRemoved++;
+            }
+        }
+        if (numRemoved > 0) {
+            base().markKeyModified(key);
+            base().notifyKeyspaceEvent(KeyspaceEvent.LREM, key);
+            if (list.isEmpty()) {
+                base().deleteValue(key);
+                base().notifyKeyspaceEvent(KeyspaceEvent.DEL, key);
             }
         }
         return Response.integer(numRemoved);

--- a/src/main/java/com/github/fppt/jedismock/operations/lists/LSet.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/lists/LSet.java
@@ -5,6 +5,7 @@ import com.github.fppt.jedismock.datastructures.Slice;
 import com.github.fppt.jedismock.operations.AbstractRedisOperation;
 import com.github.fppt.jedismock.operations.RedisCommand;
 import com.github.fppt.jedismock.server.Response;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.RedisBase;
 
 import java.util.List;
@@ -36,6 +37,8 @@ public class LSet extends AbstractRedisOperation {
         }
 
         storedData.set(index, element);
+        base().markKeyModified(key);
+        base().notifyKeyspaceEvent(KeyspaceEvent.LSET, key);
         return Response.OK;
     }
 }

--- a/src/main/java/com/github/fppt/jedismock/operations/lists/LTrim.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/lists/LTrim.java
@@ -5,6 +5,7 @@ import com.github.fppt.jedismock.datastructures.Slice;
 import com.github.fppt.jedismock.operations.AbstractRedisOperation;
 import com.github.fppt.jedismock.operations.RedisCommand;
 import com.github.fppt.jedismock.server.Response;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.RedisBase;
 
 import java.util.List;
@@ -37,6 +38,7 @@ class LTrim extends AbstractRedisOperation {
         final RMList listDBObj = getListFromBaseOrCreateEmpty(key);
         final List<Slice> list = listDBObj.getStoredData();
 
+        final int sizeBefore = list.size();
         int size = list.size();
 
         // start and end can also be negative numbers indicating offsets from the end of the list,
@@ -54,6 +56,16 @@ class LTrim extends AbstractRedisOperation {
             end = (end >= size) ? size : end + 1;
             list.subList(end, list.size()).clear();
             list.subList(0, start).clear();
+        }
+
+        //Only an actual trim is reported, and an emptied list also reports 'del'
+        if (list.size() != sizeBefore) {
+            base().markKeyModified(key);
+            base().notifyKeyspaceEvent(KeyspaceEvent.LTRIM, key);
+            if (list.isEmpty()) {
+                base().deleteValue(key);
+                base().notifyKeyspaceEvent(KeyspaceEvent.DEL, key);
+            }
         }
 
         return Response.OK;

--- a/src/main/java/com/github/fppt/jedismock/operations/lists/LTrim.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/lists/LTrim.java
@@ -38,7 +38,7 @@ class LTrim extends AbstractRedisOperation {
         final RMList listDBObj = getListFromBaseOrCreateEmpty(key);
         final List<Slice> list = listDBObj.getStoredData();
 
-        final int sizeBefore = list.size();
+        final boolean existed = base().exists(key);
         int size = list.size();
 
         // start and end can also be negative numbers indicating offsets from the end of the list,
@@ -58,8 +58,10 @@ class LTrim extends AbstractRedisOperation {
             list.subList(0, start).clear();
         }
 
-        //Only an actual trim is reported, and an emptied list also reports 'del'
-        if (list.size() != sizeBefore) {
+        //An existing list is reported as trimmed even when the range covered
+        //all of it and nothing was actually removed (unlike LREM, which only
+        //reports an actual removal). A missing key is left alone entirely.
+        if (existed) {
             base().markKeyModified(key);
             base().notifyKeyspaceEvent(KeyspaceEvent.LTRIM, key);
             if (list.isEmpty()) {

--- a/src/main/java/com/github/fppt/jedismock/operations/lists/ListPopper.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/lists/ListPopper.java
@@ -5,6 +5,7 @@ import com.github.fppt.jedismock.datastructures.Slice;
 import com.github.fppt.jedismock.exception.WrongValueTypeException;
 import com.github.fppt.jedismock.operations.AbstractRedisOperation;
 import com.github.fppt.jedismock.server.Response;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.RedisBase;
 
 import java.util.ArrayList;
@@ -12,11 +13,25 @@ import java.util.List;
 
 abstract class ListPopper extends AbstractRedisOperation {
 
+    private boolean publishEvents = true;
+
     ListPopper(RedisBase base, List<Slice> params) {
         super(base, params);
     }
 
     abstract Slice popper(List<Slice> list);
+
+    /** The event this pop reports: {@code lpop} or {@code rpop}. */
+    abstract KeyspaceEvent popEvent();
+
+    /**
+     * Suppresses this pop's own notifications, for callers that reuse it as a
+     * building block and report the composite operation themselves (see
+     * {@code RPOPLPUSH}, which must report the destination push first).
+     */
+    final void doNotPublishEvents() {
+        publishEvents = false;
+    }
 
     private Slice pop(Slice key, List<Slice> list) {
         Slice result = popper(list);
@@ -25,6 +40,20 @@ abstract class ListPopper extends AbstractRedisOperation {
             base().deleteValue(key);
         }
         return result;
+    }
+
+    /**
+     * Reports one event per command — not one per element popped — followed by
+     * the generic {@code del} if the list is now gone.
+     */
+    private void publishPop(Slice key, List<Slice> list) {
+        if (!publishEvents) {
+            return;
+        }
+        base().notifyKeyspaceEvent(popEvent(), key);
+        if (list.isEmpty()) {
+            base().notifyKeyspaceEvent(KeyspaceEvent.DEL, key);
+        }
     }
 
     protected final Slice response() {
@@ -45,9 +74,12 @@ abstract class ListPopper extends AbstractRedisOperation {
                 responseList.add(Response.bulkString(pop(key, list)));
                 count--;
             }
+            publishPop(key, list);
             return Response.array(responseList);
         } else {
-            return Response.bulkString(pop(key, list));
+            Slice popped = pop(key, list);
+            publishPop(key, list);
+            return Response.bulkString(popped);
         }
     }
 

--- a/src/main/java/com/github/fppt/jedismock/operations/lists/RPop.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/lists/RPop.java
@@ -2,6 +2,7 @@ package com.github.fppt.jedismock.operations.lists;
 
 import com.github.fppt.jedismock.datastructures.Slice;
 import com.github.fppt.jedismock.operations.RedisCommand;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.RedisBase;
 
 import java.util.List;
@@ -14,5 +15,10 @@ class RPop extends ListPopper {
 
     Slice popper(List<Slice> list) {
         return list.remove(list.size() - 1);
+    }
+
+    @Override
+    KeyspaceEvent popEvent() {
+        return KeyspaceEvent.RPOP;
     }
 }

--- a/src/main/java/com/github/fppt/jedismock/operations/lists/RPopLPush.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/lists/RPopLPush.java
@@ -5,6 +5,7 @@ import com.github.fppt.jedismock.datastructures.Slice;
 import com.github.fppt.jedismock.operations.AbstractRedisOperation;
 import com.github.fppt.jedismock.operations.RedisCommand;
 import com.github.fppt.jedismock.server.SliceParser;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.OperationExecutorState;
 
 import java.util.Arrays;
@@ -30,14 +31,23 @@ class RPopLPush extends AbstractRedisOperation {
             throw new IllegalArgumentException("WRONGTYPE Operation against a key holding the wrong kind of value");
         }
 
-        //Pop last one
-        Slice result = new RPop(base(), Collections.singletonList(source)).execute();
+        //Pop last one. Its notifications are suppressed because Redis reports
+        //the push into the destination *before* the pop from the source.
+        RPop pop = new RPop(base(), Collections.singletonList(source));
+        pop.doNotPublishEvents();
+        Slice result = pop.execute();
         if(result.equals(NULL)) return NULL;
+        boolean sourceEmptied = !base().exists(source);
 
         Slice valueToPush = SliceParser.consumeParameter(result.data());
 
-        //Push it into the other list
+        //Push it into the other list (which reports its own lpush)
         new LPush(state, Arrays.asList(target, valueToPush)).execute();
+
+        base().notifyKeyspaceEvent(KeyspaceEvent.RPOP, source);
+        if (sourceEmptied) {
+            base().notifyKeyspaceEvent(KeyspaceEvent.DEL, source);
+        }
 
         return result;
     }

--- a/src/main/java/com/github/fppt/jedismock/operations/lists/RPush.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/lists/RPush.java
@@ -1,6 +1,7 @@
 package com.github.fppt.jedismock.operations.lists;
 
 import com.github.fppt.jedismock.operations.RedisCommand;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.OperationExecutorState;
 import com.github.fppt.jedismock.datastructures.Slice;
 
@@ -15,5 +16,10 @@ class RPush extends Add {
     @Override
     void addSliceToList(List<Slice> list, Slice slice) {
         list.add(slice);
+    }
+
+    @Override
+    KeyspaceEvent pushEvent() {
+        return KeyspaceEvent.RPUSH;
     }
 }

--- a/src/main/java/com/github/fppt/jedismock/operations/lists/Sort.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/lists/Sort.java
@@ -11,6 +11,7 @@ import com.github.fppt.jedismock.exception.WrongValueTypeException;
 import com.github.fppt.jedismock.operations.AbstractRedisOperation;
 import com.github.fppt.jedismock.operations.RedisCommand;
 import com.github.fppt.jedismock.server.Response;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.OperationExecutorState;
 
 import java.util.Arrays;
@@ -61,6 +62,7 @@ public class Sort extends AbstractRedisOperation {
 
         if (storeTo != null) {
             base().putValue(storeTo, new RMList(sorted));
+            base().notifyKeyspaceEvent(KeyspaceEvent.SORTSTORE, storeTo);
             lock.notifyAll();
             return Response.integer(sorted.size());
         }

--- a/src/main/java/com/github/fppt/jedismock/operations/sets/SAdd.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/sets/SAdd.java
@@ -4,6 +4,7 @@ import com.github.fppt.jedismock.datastructures.RMSet;
 import com.github.fppt.jedismock.operations.AbstractRedisOperation;
 import com.github.fppt.jedismock.operations.RedisCommand;
 import com.github.fppt.jedismock.server.Response;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.RedisBase;
 import com.github.fppt.jedismock.datastructures.Slice;
 
@@ -30,6 +31,9 @@ class SAdd extends AbstractRedisOperation {
         }
 
         base().putValue(key, setDBObj);
+        if (count > 0) {
+            base().notifyKeyspaceEvent(KeyspaceEvent.SADD, key);
+        }
 
         return Response.integer(count);
     }

--- a/src/main/java/com/github/fppt/jedismock/operations/sets/SDiffStore.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/sets/SDiffStore.java
@@ -2,6 +2,7 @@ package com.github.fppt.jedismock.operations.sets;
 
 import com.github.fppt.jedismock.datastructures.Slice;
 import com.github.fppt.jedismock.operations.RedisCommand;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.RedisBase;
 
 import java.util.List;
@@ -12,5 +13,10 @@ class SDiffStore extends SStore {
     SDiffStore(RedisBase base, List<Slice> params) {
         super(base, params,
                 (b, p) -> new SDiff(b, p).getDifference());
+    }
+
+    @Override
+    KeyspaceEvent storeEvent() {
+        return KeyspaceEvent.SDIFFSTORE;
     }
 }

--- a/src/main/java/com/github/fppt/jedismock/operations/sets/SInterStore.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/sets/SInterStore.java
@@ -2,6 +2,7 @@ package com.github.fppt.jedismock.operations.sets;
 
 import com.github.fppt.jedismock.datastructures.Slice;
 import com.github.fppt.jedismock.operations.RedisCommand;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.RedisBase;
 
 import java.util.List;
@@ -12,5 +13,10 @@ class SInterStore extends SStore {
     SInterStore(RedisBase base, List<Slice> params) {
         super(base, params,
                 (b, p) -> new SInter(b, p).getIntersection());
+    }
+
+    @Override
+    KeyspaceEvent storeEvent() {
+        return KeyspaceEvent.SINTERSTORE;
     }
 }

--- a/src/main/java/com/github/fppt/jedismock/operations/sets/SMove.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/sets/SMove.java
@@ -29,6 +29,12 @@ public class SMove extends AbstractRedisOperation {
 
         final int result = new SRem(base(), Arrays.asList(src, member)).remove();
 
+        //The source is reported in full (including the del for the set it
+        //emptied) before the destination's sadd
+        if (result > 0) {
+            SRem.publishRemoval(base(), src);
+        }
+
         if (result > 0 && !getSetFromBaseOrCreateEmpty(dest).getStoredData().contains(member)) {
             new SAdd(base(), Arrays.asList(dest, member)).execute();
         }

--- a/src/main/java/com/github/fppt/jedismock/operations/sets/SMove.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/sets/SMove.java
@@ -1,5 +1,6 @@
 package com.github.fppt.jedismock.operations.sets;
 
+import com.github.fppt.jedismock.datastructures.RMSet;
 import com.github.fppt.jedismock.datastructures.Slice;
 import com.github.fppt.jedismock.exception.WrongValueTypeException;
 import com.github.fppt.jedismock.operations.AbstractRedisOperation;
@@ -25,6 +26,14 @@ public class SMove extends AbstractRedisOperation {
         // check destination type BEFORE deleting from src
         if (base().getValue(dest) != null && base().getSet(dest) == null) {
             throw new WrongValueTypeException("WRONGTYPE dest is not a set");
+        }
+
+        //Moving within one set changes nothing: report only whether the member
+        //is there, without touching the set or publishing any event
+        if (src.equals(dest)) {
+            RMSet set = base().getSet(src);
+            boolean isMember = set != null && set.getStoredData().contains(member);
+            return Response.integer(isMember ? 1 : 0);
         }
 
         final int result = new SRem(base(), Arrays.asList(src, member)).remove();

--- a/src/main/java/com/github/fppt/jedismock/operations/sets/SPop.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/sets/SPop.java
@@ -46,11 +46,14 @@ class SPop extends AbstractRedisOperation {
 
         List<Slice> removedElements = popper(set, numberOfElementsToBeRemoved);
 
-        //One event per command, then the generic del if the set is now gone
-        base().notifyKeyspaceEvent(KeyspaceEvent.SPOP, key);
-        if (set.isEmpty()) {
-            base().deleteValue(key);
-            base().notifyKeyspaceEvent(KeyspaceEvent.DEL, key);
+        //One event per command, and only when something was actually removed:
+        //SPOP key 0 modifies nothing and so is not reported
+        if (!removedElements.isEmpty()) {
+            base().notifyKeyspaceEvent(KeyspaceEvent.SPOP, key);
+            if (set.isEmpty()) {
+                base().deleteValue(key);
+                base().notifyKeyspaceEvent(KeyspaceEvent.DEL, key);
+            }
         }
 
         if (params().size() > 1) {

--- a/src/main/java/com/github/fppt/jedismock/operations/sets/SPop.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/sets/SPop.java
@@ -4,6 +4,7 @@ import com.github.fppt.jedismock.datastructures.Slice;
 import com.github.fppt.jedismock.operations.AbstractRedisOperation;
 import com.github.fppt.jedismock.operations.RedisCommand;
 import com.github.fppt.jedismock.server.Response;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.RedisBase;
 
 import java.util.ArrayList;
@@ -45,8 +46,11 @@ class SPop extends AbstractRedisOperation {
 
         List<Slice> removedElements = popper(set, numberOfElementsToBeRemoved);
 
+        //One event per command, then the generic del if the set is now gone
+        base().notifyKeyspaceEvent(KeyspaceEvent.SPOP, key);
         if (set.isEmpty()) {
             base().deleteValue(key);
+            base().notifyKeyspaceEvent(KeyspaceEvent.DEL, key);
         }
 
         if (params().size() > 1) {

--- a/src/main/java/com/github/fppt/jedismock/operations/sets/SRem.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/sets/SRem.java
@@ -5,6 +5,7 @@ import com.github.fppt.jedismock.operations.AbstractRedisOperation;
 import com.github.fppt.jedismock.operations.RedisCommand;
 import com.github.fppt.jedismock.server.Response;
 import com.github.fppt.jedismock.datastructures.Slice;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.RedisBase;
 
 import java.util.List;
@@ -38,6 +39,22 @@ class SRem extends AbstractRedisOperation {
     }
 
     protected Slice response() {
-        return Response.integer(remove());
+        int removed = remove();
+        if (removed > 0) {
+            publishRemoval(base(), params().get(0));
+        }
+        return Response.integer(removed);
+    }
+
+    /**
+     * Reports {@code srem}, plus the generic {@code del} if that emptied the
+     * set. Shared with {@code SMOVE}, which reuses {@link #remove()} directly
+     * and so has to report the removal itself.
+     */
+    static void publishRemoval(RedisBase base, Slice key) {
+        base.notifyKeyspaceEvent(KeyspaceEvent.SREM, key);
+        if (!base.exists(key)) {
+            base.notifyKeyspaceEvent(KeyspaceEvent.DEL, key);
+        }
     }
 }

--- a/src/main/java/com/github/fppt/jedismock/operations/sets/SStore.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/sets/SStore.java
@@ -4,6 +4,7 @@ import com.github.fppt.jedismock.datastructures.RMSet;
 import com.github.fppt.jedismock.datastructures.Slice;
 import com.github.fppt.jedismock.operations.AbstractRedisOperation;
 import com.github.fppt.jedismock.server.Response;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.RedisBase;
 
 import java.util.List;
@@ -20,14 +21,23 @@ public abstract class SStore extends AbstractRedisOperation {
         this.operation = operation;
     }
 
+    /** The event this store reports, e.g. {@code sinterstore}. */
+    abstract KeyspaceEvent storeEvent();
+
     @Override
     protected final Slice response() {
         Slice key = params().get(0);
+        boolean destinationExisted = base().exists(key);
         Set<Slice> result = operation.apply(base(), params().subList(1, params().size()));
         if (result.isEmpty()) {
             base().deleteValue(key);
+            //An empty result removes the destination, reported as a generic del
+            if (destinationExisted) {
+                base().notifyKeyspaceEvent(KeyspaceEvent.DEL, key);
+            }
         } else {
             base().putValue(key, new RMSet(result));
+            base().notifyKeyspaceEvent(storeEvent(), key);
         }
         return Response.integer(result.size());
     }

--- a/src/main/java/com/github/fppt/jedismock/operations/sets/SUnionStore.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/sets/SUnionStore.java
@@ -2,6 +2,7 @@ package com.github.fppt.jedismock.operations.sets;
 
 import com.github.fppt.jedismock.datastructures.Slice;
 import com.github.fppt.jedismock.operations.RedisCommand;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.RedisBase;
 
 import java.util.List;
@@ -12,5 +13,10 @@ class SUnionStore extends SStore {
     SUnionStore(RedisBase base, List<Slice> params) {
         super(base, params,
                 (b, p) -> new SUnion(b, p).getUnion());
+    }
+
+    @Override
+    KeyspaceEvent storeEvent() {
+        return KeyspaceEvent.SUNIONSTORE;
     }
 }

--- a/src/main/java/com/github/fppt/jedismock/operations/sortedsets/AbstractZRange.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/sortedsets/AbstractZRange.java
@@ -6,6 +6,7 @@ import com.github.fppt.jedismock.datastructures.ZSetEntry;
 import com.github.fppt.jedismock.datastructures.ZSetEntryBound;
 import com.github.fppt.jedismock.exception.ArgumentException;
 import com.github.fppt.jedismock.server.Response;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.RedisBase;
 
 import java.util.ArrayList;
@@ -141,16 +142,31 @@ abstract class AbstractZRange extends AbstractByScoreOperation {
         }
     }
 
+    /**
+     * The event a range removal reports, e.g. {@code zremrangebyscore}. Only
+     * the {@code ZREMRANGEBY*} subclasses remove, so the default is unused.
+     */
+    protected KeyspaceEvent removalEvent() {
+        return null;
+    }
+
     protected Slice remRangeFromKey(NavigableSet<ZSetEntry> entries) {
         int count = 0;
         for (ZSetEntry entry : new ArrayList<>(entries)) {
             mapDBObj.remove(entry.getValue());
             count++;
         }
-        if (mapDBObj.isEmpty()) {
+        boolean emptied = mapDBObj.isEmpty();
+        if (emptied) {
             base().deleteValue(key);
         } else {
             base().putValue(key, mapDBObj);
+        }
+        if (count > 0 && removalEvent() != null) {
+            base().notifyKeyspaceEvent(removalEvent(), key);
+            if (emptied) {
+                base().notifyKeyspaceEvent(KeyspaceEvent.DEL, key);
+            }
         }
         return Response.integer(count);
     }

--- a/src/main/java/com/github/fppt/jedismock/operations/sortedsets/AbstractZRange.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/sortedsets/AbstractZRange.java
@@ -143,14 +143,14 @@ abstract class AbstractZRange extends AbstractByScoreOperation {
     }
 
     /**
-     * The event a range removal reports, e.g. {@code zremrangebyscore}. Only
-     * the {@code ZREMRANGEBY*} subclasses remove, so the default is unused.
+     * Removes the given range, reporting it as {@code removalEvent} plus the
+     * generic {@code del} if the sorted set is now gone.
+     * <p>
+     * The event is a parameter rather than an overridable hook because most
+     * subclasses of this class only read (ZRANGE, ZCOUNT, ZLEXCOUNT, …) and
+     * never reach this method; only the {@code ZREMRANGEBY*} commands do.
      */
-    protected KeyspaceEvent removalEvent() {
-        return null;
-    }
-
-    protected Slice remRangeFromKey(NavigableSet<ZSetEntry> entries) {
+    protected Slice remRangeFromKey(NavigableSet<ZSetEntry> entries, KeyspaceEvent removalEvent) {
         int count = 0;
         for (ZSetEntry entry : new ArrayList<>(entries)) {
             mapDBObj.remove(entry.getValue());
@@ -162,8 +162,8 @@ abstract class AbstractZRange extends AbstractByScoreOperation {
         } else {
             base().putValue(key, mapDBObj);
         }
-        if (count > 0 && removalEvent() != null) {
-            base().notifyKeyspaceEvent(removalEvent(), key);
+        if (count > 0) {
+            base().notifyKeyspaceEvent(removalEvent, key);
             if (emptied) {
                 base().notifyKeyspaceEvent(KeyspaceEvent.DEL, key);
             }

--- a/src/main/java/com/github/fppt/jedismock/operations/sortedsets/ZAdd.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/sortedsets/ZAdd.java
@@ -72,7 +72,8 @@ class ZAdd extends AbstractByScoreOperation {
             if (countChange + countAdd > 0) {
                 mapDBObj.put(member, newScore);
                 base().putValue(key, mapDBObj);
-                base().notifyKeyspaceEvent(KeyspaceEvent.ZADD, key);
+                //With INCR this is an increment, reported as 'zincr' not 'zadd'
+                base().notifyKeyspaceEvent(KeyspaceEvent.ZINCR, key);
                 lock.notifyAll();
                 return Response.bulkString(Slice.create(String.valueOf(newScore)));
             }

--- a/src/main/java/com/github/fppt/jedismock/operations/sortedsets/ZAdd.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/sortedsets/ZAdd.java
@@ -5,6 +5,7 @@ import com.github.fppt.jedismock.datastructures.Slice;
 import com.github.fppt.jedismock.exception.ArgumentException;
 import com.github.fppt.jedismock.operations.RedisCommand;
 import com.github.fppt.jedismock.server.Response;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.OperationExecutorState;
 
 import java.util.EnumSet;
@@ -71,6 +72,7 @@ class ZAdd extends AbstractByScoreOperation {
             if (countChange + countAdd > 0) {
                 mapDBObj.put(member, newScore);
                 base().putValue(key, mapDBObj);
+                base().notifyKeyspaceEvent(KeyspaceEvent.ZADD, key);
                 lock.notifyAll();
                 return Response.bulkString(Slice.create(String.valueOf(newScore)));
             }
@@ -98,6 +100,7 @@ class ZAdd extends AbstractByScoreOperation {
         }
         if (countAdd + countChange > 0) {
             base().putValue(key, mapDBObj);
+            base().notifyKeyspaceEvent(KeyspaceEvent.ZADD, key);
             lock.notifyAll();
         }
         return options.contains(CH) ? Response.integer(countAdd + countChange) :

--- a/src/main/java/com/github/fppt/jedismock/operations/sortedsets/ZDiffStore.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/sortedsets/ZDiffStore.java
@@ -3,6 +3,7 @@ package com.github.fppt.jedismock.operations.sortedsets;
 import com.github.fppt.jedismock.datastructures.Slice;
 import com.github.fppt.jedismock.operations.RedisCommand;
 import com.github.fppt.jedismock.server.Response;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.OperationExecutorState;
 
 import java.util.List;
@@ -12,6 +13,11 @@ class ZDiffStore extends AbstractZDiff {
 
     ZDiffStore(OperationExecutorState state, List<Slice> params) {
         super(state, params);
+    }
+
+    @Override
+    protected KeyspaceEvent storeEvent() {
+        return KeyspaceEvent.ZDIFFSTORE;
     }
 
     @Override

--- a/src/main/java/com/github/fppt/jedismock/operations/sortedsets/ZDiffStore.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/sortedsets/ZDiffStore.java
@@ -16,13 +16,8 @@ class ZDiffStore extends AbstractZDiff {
     }
 
     @Override
-    protected KeyspaceEvent storeEvent() {
-        return KeyspaceEvent.ZDIFFSTORE;
-    }
-
-    @Override
     protected Slice response() {
-        return Response.integer(getResultSize());
+        return Response.integer(getResultSize(KeyspaceEvent.ZDIFFSTORE));
     }
 
 }

--- a/src/main/java/com/github/fppt/jedismock/operations/sortedsets/ZIncrBy.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/sortedsets/ZIncrBy.java
@@ -4,6 +4,7 @@ import com.github.fppt.jedismock.datastructures.RMZSet;
 import com.github.fppt.jedismock.datastructures.Slice;
 import com.github.fppt.jedismock.operations.RedisCommand;
 import com.github.fppt.jedismock.server.Response;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.RedisBase;
 
 import java.util.List;
@@ -41,6 +42,8 @@ public class ZIncrBy extends AbstractByScoreOperation {
 
         mapDBObj.put(member, newScore);
         base().putValue(key, mapDBObj);
+        //ZINCRBY reports 'zincr'
+        base().notifyKeyspaceEvent(KeyspaceEvent.ZINCR, key);
         return newScore;
     }
 

--- a/src/main/java/com/github/fppt/jedismock/operations/sortedsets/ZInterStore.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/sortedsets/ZInterStore.java
@@ -3,6 +3,7 @@ package com.github.fppt.jedismock.operations.sortedsets;
 import com.github.fppt.jedismock.datastructures.Slice;
 import com.github.fppt.jedismock.operations.RedisCommand;
 import com.github.fppt.jedismock.server.Response;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.OperationExecutorState;
 
 import java.util.List;
@@ -12,6 +13,11 @@ class ZInterStore extends AbstractZInter {
 
     ZInterStore(OperationExecutorState state, List<Slice> params) {
         super(state, params);
+    }
+
+    @Override
+    protected KeyspaceEvent storeEvent() {
+        return KeyspaceEvent.ZINTERSTORE;
     }
 
     @Override

--- a/src/main/java/com/github/fppt/jedismock/operations/sortedsets/ZInterStore.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/sortedsets/ZInterStore.java
@@ -16,12 +16,7 @@ class ZInterStore extends AbstractZInter {
     }
 
     @Override
-    protected KeyspaceEvent storeEvent() {
-        return KeyspaceEvent.ZINTERSTORE;
-    }
-
-    @Override
     protected Slice response() {
-        return Response.integer(getResultSize());
+        return Response.integer(getResultSize(KeyspaceEvent.ZINTERSTORE));
     }
 }

--- a/src/main/java/com/github/fppt/jedismock/operations/sortedsets/ZPop.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/sortedsets/ZPop.java
@@ -5,6 +5,7 @@ import com.github.fppt.jedismock.datastructures.Slice;
 import com.github.fppt.jedismock.datastructures.ZSetEntry;
 import com.github.fppt.jedismock.exception.ArgumentException;
 import com.github.fppt.jedismock.server.Response;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.RedisBase;
 
 import java.util.ArrayList;
@@ -50,8 +51,11 @@ class ZPop extends AbstractByScoreOperation {
                     .collect(Collectors.toList()));
             mapDBObj.remove(entry.getValue());
         }
+        //One event per command, then the generic del if the set is now gone
+        base().notifyKeyspaceEvent(isRev ? KeyspaceEvent.ZPOPMAX : KeyspaceEvent.ZPOPMIN, key);
         if (mapDBObj.isEmpty()) {
             base().deleteValue(key);
+            base().notifyKeyspaceEvent(KeyspaceEvent.DEL, key);
         }
         return result;
     }

--- a/src/main/java/com/github/fppt/jedismock/operations/sortedsets/ZPop.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/sortedsets/ZPop.java
@@ -51,11 +51,14 @@ class ZPop extends AbstractByScoreOperation {
                     .collect(Collectors.toList()));
             mapDBObj.remove(entry.getValue());
         }
-        //One event per command, then the generic del if the set is now gone
-        base().notifyKeyspaceEvent(isRev ? KeyspaceEvent.ZPOPMAX : KeyspaceEvent.ZPOPMIN, key);
-        if (mapDBObj.isEmpty()) {
-            base().deleteValue(key);
-            base().notifyKeyspaceEvent(KeyspaceEvent.DEL, key);
+        //One event per command, and only when something was actually removed:
+        //a count of 0 modifies nothing and so is not reported
+        if (!result.isEmpty()) {
+            base().notifyKeyspaceEvent(isRev ? KeyspaceEvent.ZPOPMAX : KeyspaceEvent.ZPOPMIN, key);
+            if (mapDBObj.isEmpty()) {
+                base().deleteValue(key);
+                base().notifyKeyspaceEvent(KeyspaceEvent.DEL, key);
+            }
         }
         return result;
     }

--- a/src/main/java/com/github/fppt/jedismock/operations/sortedsets/ZRangeStore.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/sortedsets/ZRangeStore.java
@@ -37,7 +37,12 @@ class ZRangeStore extends AbstractZRangeByIndex {
         params().remove(0);
         key = params().get(0);
         if (!base().exists(key)) {
+            //A missing source empties the destination, a generic del
+            boolean destinationExisted = base().exists(keyDest);
             base().deleteValue(keyDest);
+            if (destinationExisted) {
+                base().notifyKeyspaceEvent(KeyspaceEvent.DEL, keyDest);
+            }
             return Response.integer(0);
         }
         mapDBObj = base().getZSet(key);

--- a/src/main/java/com/github/fppt/jedismock/operations/sortedsets/ZRangeStore.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/sortedsets/ZRangeStore.java
@@ -6,6 +6,7 @@ import com.github.fppt.jedismock.datastructures.ZSetEntry;
 import com.github.fppt.jedismock.exception.ArgumentException;
 import com.github.fppt.jedismock.operations.RedisCommand;
 import com.github.fppt.jedismock.server.Response;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.OperationExecutorState;
 
 import java.util.ArrayList;
@@ -104,10 +105,14 @@ class ZRangeStore extends AbstractZRangeByIndex {
                 resultZSet.put(entry.getValue(), entry.getScore());
             }
         }
+        boolean destinationExisted = base().exists(keyDest);
         base().deleteValue(keyDest);
         if (!resultZSet.isEmpty()) {
             base().putValue(keyDest, resultZSet);
+            base().notifyKeyspaceEvent(KeyspaceEvent.ZRANGESTORE, keyDest);
             lock.notifyAll();
+        } else if (destinationExisted) {
+            base().notifyKeyspaceEvent(KeyspaceEvent.DEL, keyDest);
         }
         return Response.integer(resultZSet.size());
     }

--- a/src/main/java/com/github/fppt/jedismock/operations/sortedsets/ZRem.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/sortedsets/ZRem.java
@@ -5,6 +5,7 @@ import com.github.fppt.jedismock.operations.AbstractRedisOperation;
 import com.github.fppt.jedismock.operations.RedisCommand;
 import com.github.fppt.jedismock.server.Response;
 import com.github.fppt.jedismock.datastructures.Slice;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.RedisBase;
 
 import java.util.List;
@@ -29,8 +30,15 @@ class ZRem extends AbstractRedisOperation {
             }
         }
 
-        if (mapDBObj.isEmpty()) {
+        boolean emptied = mapDBObj.isEmpty();
+        if (emptied) {
             base().deleteValue(key);
+        }
+        if (count > 0) {
+            base().notifyKeyspaceEvent(KeyspaceEvent.ZREM, key);
+            if (emptied) {
+                base().notifyKeyspaceEvent(KeyspaceEvent.DEL, key);
+            }
         }
         return Response.integer(count);
     }

--- a/src/main/java/com/github/fppt/jedismock/operations/sortedsets/ZRemRangeByLex.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/sortedsets/ZRemRangeByLex.java
@@ -15,11 +15,6 @@ class ZRemRangeByLex extends AbstractZRangeByLex {
     }
 
     @Override
-    protected KeyspaceEvent removalEvent() {
-        return KeyspaceEvent.ZREMRANGEBYLEX;
-    }
-
-    @Override
     protected Slice response() {
         expectNoOptions();
         key = params().get(0);
@@ -27,6 +22,6 @@ class ZRemRangeByLex extends AbstractZRangeByLex {
 
         final Slice start = params().get(1);
         final Slice end = params().get(2);
-        return remRangeFromKey(getRange(getStartBound(start), getEndBound(end)));
+        return remRangeFromKey(getRange(getStartBound(start), getEndBound(end)), KeyspaceEvent.ZREMRANGEBYLEX);
     }
 }

--- a/src/main/java/com/github/fppt/jedismock/operations/sortedsets/ZRemRangeByLex.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/sortedsets/ZRemRangeByLex.java
@@ -2,6 +2,7 @@ package com.github.fppt.jedismock.operations.sortedsets;
 
 import com.github.fppt.jedismock.datastructures.Slice;
 import com.github.fppt.jedismock.operations.RedisCommand;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.RedisBase;
 
 import java.util.List;
@@ -11,6 +12,11 @@ class ZRemRangeByLex extends AbstractZRangeByLex {
 
     ZRemRangeByLex(RedisBase base, List<Slice> params) {
         super(base, params);
+    }
+
+    @Override
+    protected KeyspaceEvent removalEvent() {
+        return KeyspaceEvent.ZREMRANGEBYLEX;
     }
 
     @Override

--- a/src/main/java/com/github/fppt/jedismock/operations/sortedsets/ZRemRangeByRank.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/sortedsets/ZRemRangeByRank.java
@@ -16,11 +16,6 @@ public class ZRemRangeByRank extends AbstractZRangeByIndex {
     }
 
     @Override
-    protected KeyspaceEvent removalEvent() {
-        return KeyspaceEvent.ZREMRANGEBYRANK;
-    }
-
-    @Override
     protected Slice response() {
         expectNoOptions();
         key = params().get(0);
@@ -30,7 +25,7 @@ public class ZRemRangeByRank extends AbstractZRangeByIndex {
             return Response.integer(0);
         }
 
-        return remRangeFromKey(getRange(getStartBound(Slice.create(String.valueOf(startIndex))), getStartBound(Slice.create(String.valueOf(endIndex)))));
+        return remRangeFromKey(getRange(getStartBound(Slice.create(String.valueOf(startIndex))), getStartBound(Slice.create(String.valueOf(endIndex)))), KeyspaceEvent.ZREMRANGEBYRANK);
     }
 
 }

--- a/src/main/java/com/github/fppt/jedismock/operations/sortedsets/ZRemRangeByRank.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/sortedsets/ZRemRangeByRank.java
@@ -3,6 +3,7 @@ package com.github.fppt.jedismock.operations.sortedsets;
 import com.github.fppt.jedismock.datastructures.Slice;
 import com.github.fppt.jedismock.operations.RedisCommand;
 import com.github.fppt.jedismock.server.Response;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.RedisBase;
 
 import java.util.List;
@@ -12,6 +13,11 @@ public class ZRemRangeByRank extends AbstractZRangeByIndex {
 
     ZRemRangeByRank(RedisBase base, List<Slice> params) {
         super(base, params);
+    }
+
+    @Override
+    protected KeyspaceEvent removalEvent() {
+        return KeyspaceEvent.ZREMRANGEBYRANK;
     }
 
     @Override

--- a/src/main/java/com/github/fppt/jedismock/operations/sortedsets/ZRemRangeByScore.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/sortedsets/ZRemRangeByScore.java
@@ -15,11 +15,6 @@ public class ZRemRangeByScore extends AbstractZRangeByScore {
     }
 
     @Override
-    protected KeyspaceEvent removalEvent() {
-        return KeyspaceEvent.ZREMRANGEBYSCORE;
-    }
-
-    @Override
     protected Slice response() {
         expectNoOptions();
         key = params().get(0);
@@ -27,6 +22,6 @@ public class ZRemRangeByScore extends AbstractZRangeByScore {
 
         final Slice start = params().get(1);
         final Slice end = params().get(2);
-        return remRangeFromKey(getRange(getStartBound(start), getEndBound(end)));
+        return remRangeFromKey(getRange(getStartBound(start), getEndBound(end)), KeyspaceEvent.ZREMRANGEBYSCORE);
     }
 }

--- a/src/main/java/com/github/fppt/jedismock/operations/sortedsets/ZRemRangeByScore.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/sortedsets/ZRemRangeByScore.java
@@ -2,6 +2,7 @@ package com.github.fppt.jedismock.operations.sortedsets;
 
 import com.github.fppt.jedismock.datastructures.Slice;
 import com.github.fppt.jedismock.operations.RedisCommand;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.RedisBase;
 
 import java.util.List;
@@ -11,6 +12,11 @@ public class ZRemRangeByScore extends AbstractZRangeByScore {
 
     ZRemRangeByScore(RedisBase base, List<Slice> params) {
         super(base, params);
+    }
+
+    @Override
+    protected KeyspaceEvent removalEvent() {
+        return KeyspaceEvent.ZREMRANGEBYSCORE;
     }
 
     @Override

--- a/src/main/java/com/github/fppt/jedismock/operations/sortedsets/ZStore.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/sortedsets/ZStore.java
@@ -163,12 +163,17 @@ abstract class ZStore extends AbstractByScoreOperation {
         return score * weight;
     }
 
-    /** The event this store reports, e.g. {@code zunionstore}. */
-    protected KeyspaceEvent storeEvent() {
-        return null;
-    }
-
-    protected long getResultSize() {
+    /**
+     * Computes the result into the destination key, reporting it as
+     * {@code storeEvent} (or as a generic {@code del} when the result is empty
+     * and the destination therefore disappears).
+     * <p>
+     * The event is a parameter rather than an overridable hook because this
+     * class is also the base of the non-storing {@code ZDIFF}/{@code ZINTER}/
+     * {@code ZINTERCARD}/{@code ZUNION}, which never reach this method and
+     * would otherwise be forced to declare an event they do not have.
+     */
+    protected long getResultSize(KeyspaceEvent storeEvent) {
         Slice keyDest = params().get(0);
         boolean destinationExisted = base().exists(keyDest);
         if (destinationExisted) {
@@ -178,12 +183,9 @@ abstract class ZStore extends AbstractByScoreOperation {
         RMZSet mapDBObj = getFinishedZSet();
         if (!mapDBObj.isEmpty()) {
             base().putValue(keyDest, mapDBObj);
-            if (storeEvent() != null) {
-                base().notifyKeyspaceEvent(storeEvent(), keyDest);
-            }
+            base().notifyKeyspaceEvent(storeEvent, keyDest);
             lock.notifyAll();
         } else if (destinationExisted) {
-            //An empty result removes the destination, reported as a generic del
             base().notifyKeyspaceEvent(KeyspaceEvent.DEL, keyDest);
         }
         return mapDBObj.size();

--- a/src/main/java/com/github/fppt/jedismock/operations/sortedsets/ZStore.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/sortedsets/ZStore.java
@@ -5,6 +5,7 @@ import com.github.fppt.jedismock.datastructures.Slice;
 import com.github.fppt.jedismock.datastructures.ZSetEntry;
 import com.github.fppt.jedismock.exception.ArgumentException;
 import com.github.fppt.jedismock.server.Response;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.OperationExecutorState;
 
 import java.util.ArrayList;
@@ -162,16 +163,28 @@ abstract class ZStore extends AbstractByScoreOperation {
         return score * weight;
     }
 
+    /** The event this store reports, e.g. {@code zunionstore}. */
+    protected KeyspaceEvent storeEvent() {
+        return null;
+    }
+
     protected long getResultSize() {
         Slice keyDest = params().get(0);
-        if (base().exists(keyDest)) {
+        boolean destinationExisted = base().exists(keyDest);
+        if (destinationExisted) {
             base().deleteValue(keyDest);
         }
         startKeysIndex = 1;
         RMZSet mapDBObj = getFinishedZSet();
         if (!mapDBObj.isEmpty()) {
             base().putValue(keyDest, mapDBObj);
+            if (storeEvent() != null) {
+                base().notifyKeyspaceEvent(storeEvent(), keyDest);
+            }
             lock.notifyAll();
+        } else if (destinationExisted) {
+            //An empty result removes the destination, reported as a generic del
+            base().notifyKeyspaceEvent(KeyspaceEvent.DEL, keyDest);
         }
         return mapDBObj.size();
     }

--- a/src/main/java/com/github/fppt/jedismock/operations/sortedsets/ZUnionStore.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/sortedsets/ZUnionStore.java
@@ -16,12 +16,7 @@ class ZUnionStore extends AbstractZUnion {
     }
 
     @Override
-    protected KeyspaceEvent storeEvent() {
-        return KeyspaceEvent.ZUNIONSTORE;
-    }
-
-    @Override
     protected Slice response() {
-        return Response.integer(getResultSize());
+        return Response.integer(getResultSize(KeyspaceEvent.ZUNIONSTORE));
     }
 }

--- a/src/main/java/com/github/fppt/jedismock/operations/sortedsets/ZUnionStore.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/sortedsets/ZUnionStore.java
@@ -3,6 +3,7 @@ package com.github.fppt.jedismock.operations.sortedsets;
 import com.github.fppt.jedismock.datastructures.Slice;
 import com.github.fppt.jedismock.operations.RedisCommand;
 import com.github.fppt.jedismock.server.Response;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.OperationExecutorState;
 
 import java.util.List;
@@ -12,6 +13,11 @@ class ZUnionStore extends AbstractZUnion {
 
     ZUnionStore(OperationExecutorState state, List<Slice> params) {
         super(state, params);
+    }
+
+    @Override
+    protected KeyspaceEvent storeEvent() {
+        return KeyspaceEvent.ZUNIONSTORE;
     }
 
     @Override

--- a/src/main/java/com/github/fppt/jedismock/operations/streams/XAdd.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/streams/XAdd.java
@@ -8,6 +8,7 @@ import com.github.fppt.jedismock.exception.WrongStreamKeyException;
 import com.github.fppt.jedismock.operations.AbstractRedisOperation;
 import com.github.fppt.jedismock.operations.RedisCommand;
 import com.github.fppt.jedismock.server.Response;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.RedisBase;
 
 import java.util.List;
@@ -119,12 +120,14 @@ public class XAdd extends AbstractRedisOperation {
         stream.updateLastId(nodeId);
 
         base().putValue(key, stream);
+        base().notifyKeyspaceEvent(KeyspaceEvent.XADD, key);
 
+        int trimmed = 0;
         switch (criterion.toUpperCase()) {
             case "MAXLEN":
                 try {
                     int threshold = Integer.parseInt(params().get(thresholdPosition).toString());
-                    trimLen(map, threshold, limit);
+                    trimmed = trimLen(map, threshold, limit);
                 } catch (NumberFormatException e) {
                     return Response.error(SYNTAX_ERROR);
                 }
@@ -133,13 +136,17 @@ public class XAdd extends AbstractRedisOperation {
             case "MINID":
                 try {
                     StreamId threshold = new StreamId(params().get(thresholdPosition));
-                    trimID(map, threshold, limit);
+                    trimmed = trimID(map, threshold, limit);
                 } catch (WrongStreamKeyException e) {
                     return Response.error(e.getMessage());
                 }
                 break;
             default:
                 // ignored
+        }
+        //An XADD that also trims reports 'xadd' and then 'xtrim'
+        if (trimmed > 0) {
+            base().notifyKeyspaceEvent(KeyspaceEvent.XTRIM, key);
         }
 
         return Response.bulkString(nodeId.toSlice());

--- a/src/main/java/com/github/fppt/jedismock/operations/streams/XDel.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/streams/XDel.java
@@ -7,6 +7,7 @@ import com.github.fppt.jedismock.exception.WrongStreamKeyException;
 import com.github.fppt.jedismock.operations.AbstractRedisOperation;
 import com.github.fppt.jedismock.operations.RedisCommand;
 import com.github.fppt.jedismock.server.Response;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.RedisBase;
 
 import java.util.ArrayList;
@@ -45,6 +46,11 @@ public class XDel extends AbstractRedisOperation {
             if (map.remove(id) != null) {
                 removedCount++;
             }
+        }
+        if (removedCount > 0) {
+            base().markKeyModified(key);
+            //Note an emptied stream is *not* deleted, so there is no 'del' here
+            base().notifyKeyspaceEvent(KeyspaceEvent.XDEL, key);
         }
         return Response.integer(removedCount);
     }

--- a/src/main/java/com/github/fppt/jedismock/operations/streams/XTrim.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/streams/XTrim.java
@@ -8,6 +8,7 @@ import com.github.fppt.jedismock.exception.WrongStreamKeyException;
 import com.github.fppt.jedismock.operations.AbstractRedisOperation;
 import com.github.fppt.jedismock.operations.RedisCommand;
 import com.github.fppt.jedismock.server.Response;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.RedisBase;
 
 import java.util.List;
@@ -59,6 +60,15 @@ public class XTrim extends AbstractRedisOperation {
         return 3;
     }
 
+    /** Reports {@code xtrim} only if entries were actually removed. */
+    private int publishTrim(Slice key, int removed) {
+        if (removed > 0) {
+            base().markKeyModified(key);
+            base().notifyKeyspaceEvent(KeyspaceEvent.XTRIM, key);
+        }
+        return removed;
+    }
+
     @Override
     protected Slice response() {
         /* Begin parsing arguments */
@@ -103,14 +113,14 @@ public class XTrim extends AbstractRedisOperation {
             case "MAXLEN":
                 try {
                     int threshold = Integer.parseInt(params().get(thresholdPosition).toString());
-                    return Response.integer(trimLen(map, threshold, limit));
+                    return Response.integer(publishTrim(key, trimLen(map, threshold, limit)));
                 } catch (NumberFormatException e) {
                     return Response.error(SYNTAX_ERROR);
                 }
             case "MINID":
                 try {
                     StreamId threshold = new StreamId(params().get(thresholdPosition));
-                    return Response.integer(trimID(map, threshold, limit));
+                    return Response.integer(publishTrim(key, trimID(map, threshold, limit)));
                 } catch (WrongStreamKeyException e) {
                     return Response.error(e.getMessage());
                 }

--- a/src/main/java/com/github/fppt/jedismock/operations/strings/Append.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/strings/Append.java
@@ -5,6 +5,7 @@ import com.github.fppt.jedismock.operations.AbstractRedisOperation;
 import com.github.fppt.jedismock.operations.RedisCommand;
 import com.github.fppt.jedismock.server.Response;
 import com.github.fppt.jedismock.datastructures.Slice;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.RedisBase;
 
 import java.util.List;
@@ -27,11 +28,13 @@ class Append extends AbstractRedisOperation {
 
         if (s == null) {
             base().putValue(key, value.extract());
+            base().notifyKeyspaceEvent(KeyspaceEvent.APPEND, key);
             return Response.integer(value.length());
         }
 
         s.add(value.data());
         base().putValue(key, s);
+        base().notifyKeyspaceEvent(KeyspaceEvent.APPEND, key);
         return Response.integer(s.size());
     }
 }

--- a/src/main/java/com/github/fppt/jedismock/operations/strings/GetSet.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/strings/GetSet.java
@@ -4,6 +4,7 @@ import com.github.fppt.jedismock.operations.AbstractRedisOperation;
 import com.github.fppt.jedismock.operations.RedisCommand;
 import com.github.fppt.jedismock.server.Response;
 import com.github.fppt.jedismock.datastructures.Slice;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.RedisBase;
 
 import java.util.List;
@@ -17,6 +18,7 @@ class GetSet extends AbstractRedisOperation {
     protected Slice response() {
         Slice value = base().getSlice(params().get(0));
         base().putValue(params().get(0), params().get(1).extract());
+        base().notifyKeyspaceEvent(KeyspaceEvent.SET, params().get(0));
         return Response.bulkString(value);
     }
 }

--- a/src/main/java/com/github/fppt/jedismock/operations/strings/IncrOrDecrBy.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/strings/IncrOrDecrBy.java
@@ -4,6 +4,7 @@ import com.github.fppt.jedismock.datastructures.RMString;
 import com.github.fppt.jedismock.operations.AbstractRedisOperation;
 import com.github.fppt.jedismock.server.Response;
 import com.github.fppt.jedismock.datastructures.Slice;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.RedisBase;
 
 import java.util.List;
@@ -24,11 +25,14 @@ abstract class IncrOrDecrBy extends AbstractRedisOperation {
 
         if (v == null) {
             base().putValue(key, RMString.create(String.valueOf(d)));
+            base().notifyKeyspaceEvent(KeyspaceEvent.INCRBY, key);
             return Response.integer(d);
         }
 
         long r = convertToLong(v.getStoredDataAsString()) + d;
         base().putValueWithoutClearingTtl(key, RMString.create(String.valueOf(r)));
+        //Reported as 'incrby' whichever of INCR/INCRBY/DECR/DECRBY was issued
+        base().notifyKeyspaceEvent(KeyspaceEvent.INCRBY, key);
         return Response.integer(r);
     }
 }

--- a/src/main/java/com/github/fppt/jedismock/operations/strings/IncrOrDecrByFloat.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/strings/IncrOrDecrByFloat.java
@@ -4,6 +4,7 @@ import com.github.fppt.jedismock.datastructures.RMString;
 import com.github.fppt.jedismock.operations.AbstractRedisOperation;
 import com.github.fppt.jedismock.server.Response;
 import com.github.fppt.jedismock.datastructures.Slice;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.RedisBase;
 
 import java.math.BigDecimal;
@@ -44,6 +45,7 @@ abstract class IncrOrDecrByFloat extends AbstractRedisOperation {
 
         RMString res = RMString.create(data);
         base().putValue(key, res);
+        base().notifyKeyspaceEvent(KeyspaceEvent.INCRBYFLOAT, key);
 
         return Response.bulkString(res.getAsSlice());
     }

--- a/src/main/java/com/github/fppt/jedismock/operations/strings/MSet.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/strings/MSet.java
@@ -4,6 +4,7 @@ import com.github.fppt.jedismock.operations.AbstractRedisOperation;
 import com.github.fppt.jedismock.operations.RedisCommand;
 import com.github.fppt.jedismock.server.Response;
 import com.github.fppt.jedismock.datastructures.Slice;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.RedisBase;
 
 import java.util.List;
@@ -17,6 +18,7 @@ class MSet extends AbstractRedisOperation {
     protected Slice response() {
         for (int i = 0; i < params().size(); i += 2) {
             base().putValue(params().get(i), params().get(i + 1).extract());
+            base().notifyKeyspaceEvent(KeyspaceEvent.SET, params().get(i));
         }
         return Response.OK;
     }

--- a/src/main/java/com/github/fppt/jedismock/operations/strings/MSetNX.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/strings/MSetNX.java
@@ -4,6 +4,7 @@ import com.github.fppt.jedismock.datastructures.Slice;
 import com.github.fppt.jedismock.operations.AbstractRedisOperation;
 import com.github.fppt.jedismock.operations.RedisCommand;
 import com.github.fppt.jedismock.server.Response;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.RedisBase;
 
 import java.util.List;
@@ -24,6 +25,7 @@ public class MSetNX extends AbstractRedisOperation {
         }
         for (int i = 0; i < params().size(); i += 2) {
             base.putValue(params().get(i), params().get(i + 1).extract());
+            base.notifyKeyspaceEvent(KeyspaceEvent.SET, params().get(i));
         }
         return Response.integer(1);
     }

--- a/src/main/java/com/github/fppt/jedismock/operations/strings/Set.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/strings/Set.java
@@ -89,12 +89,14 @@ class Set extends AbstractRedisOperation {
     }
 
     /**
-     * Setting an expiration alongside the value publishes a generic
-     * {@code expire} notification (in addition to the string-class {@code set}
-     * one), exactly as a separate {@code EXPIRE} would.
+     * Reports the assignment, then — when the command also set an expiration —
+     * the generic {@code expire}, in that order, exactly as real Redis does.
      */
-    private void notifyExpirationSet(Slice key) {
-        base().notifyKeyspaceEvent(KeyspaceEvent.EXPIRE, key);
+    private void notifyStored(Slice key, boolean expirationSet) {
+        base().notifyKeyspaceEvent(KeyspaceEvent.SET, key);
+        if (expirationSet) {
+            base().notifyKeyspaceEvent(KeyspaceEvent.EXPIRE, key);
+        }
     }
 
     private BiConsumer<Slice, RMDataStructure> valueSetter() {
@@ -104,27 +106,27 @@ class Set extends AbstractRedisOperation {
                 long ex = parseAndValidate(param, 1000);
                 return (k, v) -> {
                     base().putValue(k, v, ex);
-                    notifyExpirationSet(k);
+                    notifyStored(k, true);
                 };
             } else if ("px".equalsIgnoreCase(previous)) {
                 long px = parseAndValidate(param, 1);
                 return (k, v) -> {
                     base().putValue(k, v, px);
-                    notifyExpirationSet(k);
+                    notifyStored(k, true);
                 };
             } else if ("exat".equalsIgnoreCase(previous)) {
                 long exat = parseAndValidate(param, 1000);
                 return (k, v) -> {
                     base().putValue(k, v);
                     base().setDeadline(k, exat);
-                    notifyExpirationSet(k);
+                    notifyStored(k, true);
                 };
             } else if ("pxat".equalsIgnoreCase(previous)) {
                 long pxat = parseAndValidate(param, 1);
                 return (k, v) -> {
                     base().putValue(k, v);
                     base().setDeadline(k, pxat);
-                    notifyExpirationSet(k);
+                    notifyStored(k, true);
                 };
             }
             previous = param;
@@ -136,9 +138,13 @@ class Set extends AbstractRedisOperation {
                 if (deadline != null) {
                     base().setDeadline(k, deadline);
                 }
+                notifyStored(k, false);
             };
         } else {
-            return (k, v) -> base().putValue(k, v);
+            return (k, v) -> {
+                base().putValue(k, v);
+                notifyStored(k, false);
+            };
         }
     }
 }

--- a/src/main/java/com/github/fppt/jedismock/operations/strings/SetEx.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/strings/SetEx.java
@@ -32,7 +32,8 @@ class SetEx extends Set {
             return Response.error(String.format("ERR invalid expire time in '%s' command", self().value()));
         }
         base().putValue(params().get(0), params().get(2).extract(), timeout);
-        //As with SET ... EX, the expiration is reported as a generic 'expire'
+        //As with SET ... EX: the string 'set', then the generic 'expire'
+        base().notifyKeyspaceEvent(KeyspaceEvent.SET, params().get(0));
         base().notifyKeyspaceEvent(KeyspaceEvent.EXPIRE, params().get(0));
         return Response.OK;
     }

--- a/src/main/java/com/github/fppt/jedismock/operations/strings/SetNX.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/strings/SetNX.java
@@ -4,6 +4,7 @@ import com.github.fppt.jedismock.operations.AbstractRedisOperation;
 import com.github.fppt.jedismock.operations.RedisCommand;
 import com.github.fppt.jedismock.server.Response;
 import com.github.fppt.jedismock.datastructures.Slice;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.RedisBase;
 
 import java.util.List;
@@ -17,6 +18,7 @@ class SetNX extends AbstractRedisOperation {
     protected Slice response(){
         if (base().getValue(params().get(0)) == null) {
             base().putValue(params().get(0), params().get(1).extract());
+            base().notifyKeyspaceEvent(KeyspaceEvent.SET, params().get(0));
             return Response.integer(1);
         }
         return Response.integer(0);

--- a/src/main/java/com/github/fppt/jedismock/operations/strings/SetRange.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/strings/SetRange.java
@@ -47,7 +47,9 @@ public class SetRange extends AbstractRedisOperation {
         if (offset + value.length() < oldValue.length()) {
             newValue += oldValue.substring(offset + value.length());
         }
-        if (!oldValue.equals(newValue)) {
+        //An empty value writes nothing at all; anything else is a write (and so
+        //is reported) even when the resulting string is identical
+        if (value.length() > 0) {
             base().putValue(key, Slice.create(newValue).extract(), null);
             base().notifyKeyspaceEvent(KeyspaceEvent.SETRANGE, key);
         }

--- a/src/main/java/com/github/fppt/jedismock/operations/strings/SetRange.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/strings/SetRange.java
@@ -5,6 +5,7 @@ import com.github.fppt.jedismock.datastructures.Slice;
 import com.github.fppt.jedismock.operations.AbstractRedisOperation;
 import com.github.fppt.jedismock.operations.RedisCommand;
 import com.github.fppt.jedismock.server.Response;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.RedisBase;
 
 import java.util.List;
@@ -48,6 +49,7 @@ public class SetRange extends AbstractRedisOperation {
         }
         if (!oldValue.equals(newValue)) {
             base().putValue(key, Slice.create(newValue).extract(), null);
+            base().notifyKeyspaceEvent(KeyspaceEvent.SETRANGE, key);
         }
         return Response.integer(newValue.length());
     }

--- a/src/main/java/com/github/fppt/jedismock/storage/ExpiringKeyValueStorage.java
+++ b/src/main/java/com/github/fppt/jedismock/storage/ExpiringKeyValueStorage.java
@@ -38,6 +38,19 @@ public class ExpiringKeyValueStorage extends ExpiringStorage {
     }
 
     /**
+     * Processes a pending passive expiry before a write, so that overwriting a
+     * key whose TTL has already elapsed reports {@code expired} and then
+     * counts as a creation — as it does in real Redis, where the write's key
+     * lookup expires the old key first. Without this the stale entry would
+     * still be present and suppress the {@code new} event.
+     */
+    private void expireIfOutdated(Slice key) {
+        if (values.containsKey(key) && isKeyOutdated(key)) {
+            deleteExpired(key);
+        }
+    }
+
+    /**
      * Reports the {@code new} event if this write brings the key into
      * existence. Called before the value is stored, so that {@code new}
      * precedes the command's own event, as in real Redis.
@@ -126,6 +139,7 @@ public class ExpiringKeyValueStorage extends ExpiringStorage {
 
     public void put(Slice key, RMDataStructure value, Long ttl) {
         keyChangeNotifier.accept(key);
+        expireIfOutdated(key);
         publishIfNewKey(key);
         values().put(key, value);
         configureTTL(key, ttl);
@@ -136,6 +150,7 @@ public class ExpiringKeyValueStorage extends ExpiringStorage {
         keyChangeNotifier.accept(key);
         Objects.requireNonNull(key);
         Objects.requireNonNull(value);
+        expireIfOutdated(key);
         publishIfNewKey(key);
         values().put(key, value.extract());
         configureTTL(key, ttl);
@@ -149,6 +164,7 @@ public class ExpiringKeyValueStorage extends ExpiringStorage {
         Objects.requireNonNull(value);
         RMHash mapByKey;
 
+        expireIfOutdated(key1);
         if (!values.containsKey(key1)) {
             eventPublisher.accept(KeyspaceEvent.NEW, key1);
             mapByKey = new RMHash(getClockSupplier());

--- a/src/main/java/com/github/fppt/jedismock/storage/ExpiringKeyValueStorage.java
+++ b/src/main/java/com/github/fppt/jedismock/storage/ExpiringKeyValueStorage.java
@@ -8,17 +8,23 @@ import java.time.Clock;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 public class ExpiringKeyValueStorage extends ExpiringStorage {
     private final Map<Slice, RMDataStructure> values = new HashMap<>();
-    private final Consumer<Slice> expiredKeyNotifier;
+    private final BiConsumer<KeyspaceEvent, Slice> eventPublisher;
 
+    /**
+     * @param eventPublisher publishes the keyspace notifications this layer is
+     * responsible for: {@code expired} for a passive expiry, and {@code new}
+     * for a key that did not exist before a write
+     */
     public ExpiringKeyValueStorage(Supplier<Clock> clockSupplier, Consumer<Slice> keyChangeNotifier,
-                                   Consumer<Slice> expiredKeyNotifier) {
+                                   BiConsumer<KeyspaceEvent, Slice> eventPublisher) {
         super(clockSupplier, keyChangeNotifier);
-        this.expiredKeyNotifier = Objects.requireNonNull(expiredKeyNotifier);
+        this.eventPublisher = Objects.requireNonNull(eventPublisher);
     }
 
     /**
@@ -28,7 +34,18 @@ public class ExpiringKeyValueStorage extends ExpiringStorage {
      */
     public void deleteExpired(Slice key) {
         delete(key);
-        expiredKeyNotifier.accept(key);
+        eventPublisher.accept(KeyspaceEvent.EXPIRED, key);
+    }
+
+    /**
+     * Reports the {@code new} event if this write brings the key into
+     * existence. Called before the value is stored, so that {@code new}
+     * precedes the command's own event, as in real Redis.
+     */
+    private void publishIfNewKey(Slice key) {
+        if (!values.containsKey(key)) {
+            eventPublisher.accept(KeyspaceEvent.NEW, key);
+        }
     }
 
     public Map<Slice, RMDataStructure> values() {
@@ -109,6 +126,7 @@ public class ExpiringKeyValueStorage extends ExpiringStorage {
 
     public void put(Slice key, RMDataStructure value, Long ttl) {
         keyChangeNotifier.accept(key);
+        publishIfNewKey(key);
         values().put(key, value);
         configureTTL(key, ttl);
     }
@@ -118,6 +136,7 @@ public class ExpiringKeyValueStorage extends ExpiringStorage {
         keyChangeNotifier.accept(key);
         Objects.requireNonNull(key);
         Objects.requireNonNull(value);
+        publishIfNewKey(key);
         values().put(key, value.extract());
         configureTTL(key, ttl);
     }
@@ -131,6 +150,7 @@ public class ExpiringKeyValueStorage extends ExpiringStorage {
         RMHash mapByKey;
 
         if (!values.containsKey(key1)) {
+            eventPublisher.accept(KeyspaceEvent.NEW, key1);
             mapByKey = new RMHash(getClockSupplier());
             values.put(key1, mapByKey);
         } else {

--- a/src/main/java/com/github/fppt/jedismock/storage/KeyspaceEvent.java
+++ b/src/main/java/com/github/fppt/jedismock/storage/KeyspaceEvent.java
@@ -45,7 +45,35 @@ public enum KeyspaceEvent {
     LSET("lset", EventClass.LIST),
     LREM("lrem", EventClass.LIST),
     LTRIM("ltrim", EventClass.LIST),
-    SORTSTORE("sortstore", EventClass.LIST);
+    SORTSTORE("sortstore", EventClass.LIST),
+
+    //Set (s)
+    SADD("sadd", EventClass.SET),
+    SREM("srem", EventClass.SET),
+    SPOP("spop", EventClass.SET),
+    SINTERSTORE("sinterstore", EventClass.SET),
+    SUNIONSTORE("sunionstore", EventClass.SET),
+    SDIFFSTORE("sdiffstore", EventClass.SET),
+
+    //Sorted set (z). Note ZINCRBY reports "zincr".
+    ZADD("zadd", EventClass.ZSET),
+    ZINCR("zincr", EventClass.ZSET),
+    ZREM("zrem", EventClass.ZSET),
+    ZREMRANGEBYSCORE("zremrangebyscore", EventClass.ZSET),
+    ZREMRANGEBYRANK("zremrangebyrank", EventClass.ZSET),
+    ZREMRANGEBYLEX("zremrangebylex", EventClass.ZSET),
+    ZUNIONSTORE("zunionstore", EventClass.ZSET),
+    ZINTERSTORE("zinterstore", EventClass.ZSET),
+    ZDIFFSTORE("zdiffstore", EventClass.ZSET),
+    ZRANGESTORE("zrangestore", EventClass.ZSET),
+    ZPOPMIN("zpopmin", EventClass.ZSET),
+    ZPOPMAX("zpopmax", EventClass.ZSET),
+
+    //Hash (h). HSET, HMSET and HSETNX all report "hset".
+    HSET("hset", EventClass.HASH),
+    HDEL("hdel", EventClass.HASH),
+    HINCRBY("hincrby", EventClass.HASH),
+    HINCRBYFLOAT("hincrbyfloat", EventClass.HASH);
 
     private final String eventName;
     private final EventClass eventClass;

--- a/src/main/java/com/github/fppt/jedismock/storage/KeyspaceEvent.java
+++ b/src/main/java/com/github/fppt/jedismock/storage/KeyspaceEvent.java
@@ -33,7 +33,19 @@ public enum KeyspaceEvent {
     APPEND("append", EventClass.STRING),
     SETRANGE("setrange", EventClass.STRING),
     INCRBY("incrby", EventClass.STRING),
-    INCRBYFLOAT("incrbyfloat", EventClass.STRING);
+    INCRBYFLOAT("incrbyfloat", EventClass.STRING),
+
+    //List (l). A multi-element push reports one event, and the conditional
+    //(X) variants report the same event as their unconditional forms.
+    LPUSH("lpush", EventClass.LIST),
+    RPUSH("rpush", EventClass.LIST),
+    LPOP("lpop", EventClass.LIST),
+    RPOP("rpop", EventClass.LIST),
+    LINSERT("linsert", EventClass.LIST),
+    LSET("lset", EventClass.LIST),
+    LREM("lrem", EventClass.LIST),
+    LTRIM("ltrim", EventClass.LIST),
+    SORTSTORE("sortstore", EventClass.LIST);
 
     private final String eventName;
     private final EventClass eventClass;

--- a/src/main/java/com/github/fppt/jedismock/storage/KeyspaceEvent.java
+++ b/src/main/java/com/github/fppt/jedismock/storage/KeyspaceEvent.java
@@ -80,7 +80,11 @@ public enum KeyspaceEvent {
     //because the mock does not implement the consumer-group commands.
     XADD("xadd", EventClass.STREAM),
     XTRIM("xtrim", EventClass.STREAM),
-    XDEL("xdel", EventClass.STREAM);
+    XDEL("xdel", EventClass.STREAM),
+
+    //New key (n): published once, before the type's own event, when a key
+    //first comes into existence. Not covered by the 'A' alias.
+    NEW("new", EventClass.NEW);
 
     private final String eventName;
     private final EventClass eventClass;

--- a/src/main/java/com/github/fppt/jedismock/storage/KeyspaceEvent.java
+++ b/src/main/java/com/github/fppt/jedismock/storage/KeyspaceEvent.java
@@ -73,7 +73,14 @@ public enum KeyspaceEvent {
     HSET("hset", EventClass.HASH),
     HDEL("hdel", EventClass.HASH),
     HINCRBY("hincrby", EventClass.HASH),
-    HINCRBYFLOAT("hincrbyfloat", EventClass.HASH);
+    HINCRBYFLOAT("hincrbyfloat", EventClass.HASH),
+
+    //Stream (t). The consumer-group events (xgroup-create and friends, whose
+    //names are hyphenated rather than being valid Java identifiers) are absent
+    //because the mock does not implement the consumer-group commands.
+    XADD("xadd", EventClass.STREAM),
+    XTRIM("xtrim", EventClass.STREAM),
+    XDEL("xdel", EventClass.STREAM);
 
     private final String eventName;
     private final EventClass eventClass;

--- a/src/main/java/com/github/fppt/jedismock/storage/KeyspaceEvent.java
+++ b/src/main/java/com/github/fppt/jedismock/storage/KeyspaceEvent.java
@@ -13,6 +13,8 @@ import com.github.fppt.jedismock.storage.KeyspaceNotificationOptions.EventClass;
  * {@code xgroup-create}, which is not a valid identifier).
  */
 public enum KeyspaceEvent {
+    //Generic (g): not tied to one value type. Note that a container emptied by
+    //its own type's command is reported with this class, not the type's.
     DEL("del", EventClass.GENERIC),
     EXPIRE("expire", EventClass.GENERIC),
     PERSIST("persist", EventClass.GENERIC),
@@ -21,7 +23,17 @@ public enum KeyspaceEvent {
     MOVE_FROM("move_from", EventClass.GENERIC),
     MOVE_TO("move_to", EventClass.GENERIC),
     COPY_TO("copy_to", EventClass.GENERIC),
-    EXPIRED("expired", EventClass.EXPIRED);
+
+    //Expired (x)
+    EXPIRED("expired", EventClass.EXPIRED),
+
+    //String ($). Every flavour of assignment reports "set", and the
+    //decrementing variants report "incrby" just like the incrementing ones.
+    SET("set", EventClass.STRING),
+    APPEND("append", EventClass.STRING),
+    SETRANGE("setrange", EventClass.STRING),
+    INCRBY("incrby", EventClass.STRING),
+    INCRBYFLOAT("incrbyfloat", EventClass.STRING);
 
     private final String eventName;
     private final EventClass eventClass;

--- a/src/main/java/com/github/fppt/jedismock/storage/RedisBase.java
+++ b/src/main/java/com/github/fppt/jedismock/storage/RedisBase.java
@@ -46,7 +46,7 @@ public class RedisBase {
         this.keyValueStorage = new ExpiringKeyValueStorage(clockSupplier, key -> watchedKeys
                 .getOrDefault(key, Collections.emptySet())
                 .forEach(OperationExecutorState::watchedKeyIsAffected),
-                key -> notifyKeyspaceEvent(KeyspaceEvent.EXPIRED, key));
+                this::notifyKeyspaceEvent);
     }
 
     /**
@@ -58,7 +58,7 @@ public class RedisBase {
      * {@code __keyevent@<db>__:<event> -> <key>}. Only call while holding
      * {@link OperationExecutorState#lock()} (all operations do).
      */
-    public void notifyKeyspaceEvent(KeyspaceEvent event, Slice key) {
+    public final void notifyKeyspaceEvent(KeyspaceEvent event, Slice key) {
         KeyspaceNotificationOptions options = configuration.getKeyspaceNotificationOptions();
         if (!options.isEnabled(event)) {
             return;

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/notifications/CollectionKeyspaceNotificationsTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/notifications/CollectionKeyspaceNotificationsTest.java
@@ -1,0 +1,200 @@
+package com.github.fppt.jedismock.comparisontests.notifications;
+
+import com.github.fppt.jedismock.comparisontests.ComparisonBase;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.params.ZRangeParams;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static com.github.fppt.jedismock.comparisontests.notifications.NotificationCollector.collectorFor;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Keyspace notifications of the set ({@code s}), sorted set ({@code z}) and
+ * hash ({@code h}) event classes.
+ * <p>
+ * As with lists, emptying a container additionally reports a <em>generic</em>
+ * {@code del}, and a command that changes nothing reports nothing.
+ */
+@ExtendWith(ComparisonBase.class)
+public class CollectionKeyspaceNotificationsTest {
+
+    @TestTemplate
+    public void setMutationsPublishTheirEvents(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "Es")) {
+            jedis.sadd("myset", "a", "b", "c", "d");
+            //Adding a member that is already present changes nothing
+            jedis.sadd("myset", "a");
+            //Removing a member that is not there changes nothing
+            jedis.srem("myset", "x");
+            jedis.sadd("myset", "x", "y", "z");
+            jedis.srem("myset", "x");
+            //SPOP removes a random member, so it goes last to keep this
+            //sequence deterministic
+            jedis.spop("myset");
+            assertThat(events.next(4)).containsExactly(
+                    "__keyevent@0__:sadd -> myset",
+                    "__keyevent@0__:sadd -> myset",
+                    "__keyevent@0__:srem -> myset",
+                    "__keyevent@0__:spop -> myset");
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    @TestTemplate
+    public void setStoreCommandsPublishForTheDestination(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "Es")) {
+            jedis.sadd("s1", "a", "b");
+            jedis.sadd("s2", "b", "c");
+            jedis.sinterstore("d1", "s1", "s2");
+            jedis.sunionstore("d2", "s1", "s2");
+            jedis.sdiffstore("d3", "s1", "s2");
+            assertThat(events.next(5)).containsExactly(
+                    "__keyevent@0__:sadd -> s1",
+                    "__keyevent@0__:sadd -> s2",
+                    "__keyevent@0__:sinterstore -> d1",
+                    "__keyevent@0__:sunionstore -> d2",
+                    "__keyevent@0__:sdiffstore -> d3");
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    @TestTemplate
+    public void smovePublishesSremThenSadd(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "Esg")) {
+            jedis.sadd("src", "only");
+            jedis.sadd("dst", "other");
+            jedis.smove("src", "dst", "only");
+            assertThat(events.next(5)).containsExactly(
+                    "__keyevent@0__:sadd -> src",
+                    "__keyevent@0__:sadd -> dst",
+                    //The source is fully reported (including the del for the
+                    //container it emptied) before the destination — the
+                    //opposite order to RPOPLPUSH
+                    "__keyevent@0__:srem -> src",
+                    "__keyevent@0__:del -> src",
+                    "__keyevent@0__:sadd -> dst");
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    @TestTemplate
+    public void emptyingASetPublishesGenericDel(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "Esg")) {
+            jedis.sadd("e1", "only");
+            jedis.spop("e1");
+            jedis.sadd("e2", "only");
+            jedis.srem("e2", "only");
+            assertThat(events.next(6)).containsExactly(
+                    "__keyevent@0__:sadd -> e1",
+                    "__keyevent@0__:spop -> e1",
+                    "__keyevent@0__:del -> e1",
+                    "__keyevent@0__:sadd -> e2",
+                    "__keyevent@0__:srem -> e2",
+                    "__keyevent@0__:del -> e2");
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    @TestTemplate
+    public void sortedSetMutationsPublishTheirEvents(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "Ez")) {
+            jedis.zadd("myzset", 1, "a");
+            jedis.zadd("myzset", 2, "b");
+            //ZINCRBY reports 'zincr', not 'zincrby'
+            jedis.zincrby("myzset", 1, "a");
+            jedis.zrem("myzset", "nosuchmember");
+            jedis.zrem("myzset", "a");
+            jedis.zadd("myzset", 3, "c");
+            jedis.zremrangeByScore("myzset", 3, 3);
+            jedis.zadd("myzset", 4, "d");
+            jedis.zremrangeByRank("myzset", 0, 0);
+            jedis.zadd("myzset", 5, "lex");
+            jedis.zremrangeByLex("myzset", "[lex", "[lex");
+            assertThat(events.next(9)).containsExactly(
+                    "__keyevent@0__:zadd -> myzset",
+                    "__keyevent@0__:zadd -> myzset",
+                    "__keyevent@0__:zincr -> myzset",
+                    "__keyevent@0__:zrem -> myzset",
+                    "__keyevent@0__:zadd -> myzset",
+                    "__keyevent@0__:zremrangebyscore -> myzset",
+                    "__keyevent@0__:zadd -> myzset",
+                    "__keyevent@0__:zremrangebyrank -> myzset",
+                    "__keyevent@0__:zadd -> myzset");
+            assertThat(events.next(1)).containsExactly(
+                    "__keyevent@0__:zremrangebylex -> myzset");
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    @TestTemplate
+    public void sortedSetStoreAndPopCommandsPublishTheirEvents(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "Ez")) {
+            jedis.zadd("z1", 1, "a");
+            jedis.zadd("z2", 2, "b");
+            jedis.zunionstore("u", "z1", "z2");
+            jedis.zinterstore("i", "z1", "z1");
+            jedis.zrangestore("r", "z1", ZRangeParams.zrangeParams(0, -1));
+            jedis.zpopmin("u");
+            jedis.zpopmax("u");
+            assertThat(events.next(7)).containsExactly(
+                    "__keyevent@0__:zadd -> z1",
+                    "__keyevent@0__:zadd -> z2",
+                    "__keyevent@0__:zunionstore -> u",
+                    "__keyevent@0__:zinterstore -> i",
+                    "__keyevent@0__:zrangestore -> r",
+                    "__keyevent@0__:zpopmin -> u",
+                    "__keyevent@0__:zpopmax -> u");
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    @TestTemplate
+    public void hashMutationsPublishTheirEvents(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "Eh")) {
+            Map<String, String> fields = new LinkedHashMap<>();
+            fields.put("yes", "1");
+            fields.put("no", "0");
+            //All of HSET, HMSET and HSETNX report 'hset'
+            jedis.hmset("myhash", fields);
+            jedis.hset("myhash", "other", "v");
+            jedis.hsetnx("myhash", "fresh", "v");
+            //HSETNX on an existing field changes nothing
+            jedis.hsetnx("myhash", "fresh", "w");
+            jedis.hincrBy("myhash", "yes", 10);
+            jedis.hincrByFloat("myhash", "yes", 1.5);
+            jedis.hdel("myhash", "nosuchfield");
+            jedis.hdel("myhash", "other");
+            assertThat(events.next(6)).containsExactly(
+                    "__keyevent@0__:hset -> myhash",
+                    "__keyevent@0__:hset -> myhash",
+                    "__keyevent@0__:hset -> myhash",
+                    "__keyevent@0__:hincrby -> myhash",
+                    "__keyevent@0__:hincrbyfloat -> myhash",
+                    "__keyevent@0__:hdel -> myhash");
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    @TestTemplate
+    public void emptyingAHashOrSortedSetPublishesGenericDel(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "Ehzg")) {
+            jedis.hset("eh", "f", "v");
+            jedis.hdel("eh", "f");
+            jedis.zadd("ez", 1, "only");
+            jedis.zrem("ez", "only");
+            assertThat(events.next(6)).containsExactly(
+                    "__keyevent@0__:hset -> eh",
+                    "__keyevent@0__:hdel -> eh",
+                    "__keyevent@0__:del -> eh",
+                    "__keyevent@0__:zadd -> ez",
+                    "__keyevent@0__:zrem -> ez",
+                    "__keyevent@0__:del -> ez");
+            events.assertNoFurtherNotifications();
+        }
+    }
+}

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/notifications/CollectionKeyspaceNotificationsTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/notifications/CollectionKeyspaceNotificationsTest.java
@@ -46,6 +46,33 @@ public class CollectionKeyspaceNotificationsTest {
     }
 
     @TestTemplate
+    public void popWithAZeroCountPublishesNothing(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        //A pop of zero elements modifies nothing, so it is not reported
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "Eszg")) {
+            jedis.sadd("s", "a", "b");
+            jedis.zadd("z", 1, "a");
+            assertThat(events.next(2)).containsExactly(
+                    "__keyevent@0__:sadd -> s",
+                    "__keyevent@0__:zadd -> z");
+            jedis.spop("s", 0);
+            jedis.zpopmin("z", 0);
+            jedis.zpopmax("z", 0);
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    @TestTemplate
+    public void popOfAMissingKeyPublishesNothing(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "Eszg")) {
+            jedis.spop("nosuchset");
+            jedis.spop("nosuchset", 2);
+            jedis.zpopmin("nosuchzset");
+            jedis.zpopmax("nosuchzset", 2);
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    @TestTemplate
     public void setStoreCommandsPublishForTheDestination(Jedis jedis, HostAndPort hostAndPort) throws Exception {
         try (NotificationCollector events = collectorFor(jedis, hostAndPort, "Es")) {
             jedis.sadd("s1", "a", "b");

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/notifications/GenericKeyspaceNotificationsTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/notifications/GenericKeyspaceNotificationsTest.java
@@ -6,19 +6,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.testcontainers.shaded.org.awaitility.Awaitility;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.Jedis;
-import redis.clients.jedis.JedisPubSub;
 import redis.clients.jedis.params.SetParams;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-
+import static com.github.fppt.jedismock.comparisontests.notifications.NotificationCollector.collectorFor;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -32,64 +22,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @ExtendWith(ComparisonBase.class)
 public class GenericKeyspaceNotificationsTest {
-
-    private static final String PARAM = "notify-keyspace-events";
-
-    static class NotificationCollector implements AutoCloseable {
-        private final Jedis client;
-        private final BlockingQueue<String> events = new LinkedBlockingQueue<>();
-        private final JedisPubSub subscriber;
-        private final ExecutorService service = Executors.newSingleThreadExecutor();
-        private final Future<?> future;
-
-        NotificationCollector(HostAndPort hostAndPort) {
-            client = new Jedis(hostAndPort.getHost(), hostAndPort.getPort());
-            subscriber = new JedisPubSub() {
-                @Override
-                public void onPMessage(String pattern, String channel, String message) {
-                    events.add(channel + " -> " + message);
-                }
-            };
-            future = service.submit(() -> client.psubscribe(subscriber, "__key*@*__:*"));
-        }
-
-        /** Waits for exactly {@code count} notifications and returns them in arrival order. */
-        List<String> next(int count) throws InterruptedException {
-            List<String> received = new ArrayList<>();
-            for (int i = 0; i < count; i++) {
-                String event = events.poll(10, TimeUnit.SECONDS);
-                assertThat(event).as("notification %d of %d (got %s)", i + 1, count, received).isNotNull();
-                received.add(event);
-            }
-            return received;
-        }
-
-        void assertNoFurtherNotifications() throws InterruptedException {
-            assertThat(events.poll(300, TimeUnit.MILLISECONDS)).isNull();
-        }
-
-        @Override
-        public void close() throws Exception {
-            try {
-                subscriber.punsubscribe();
-                future.get(5, TimeUnit.SECONDS);
-            } catch (TimeoutException e) {
-                //Fall through to the forced disconnect below.
-            } finally {
-                service.shutdownNow();
-                client.disconnect();
-                client.close();
-            }
-        }
-    }
-
-    private static NotificationCollector collectorFor(Jedis jedis, HostAndPort hostAndPort, String flags) {
-        jedis.flushAll();
-        jedis.configSet(PARAM, flags);
-        NotificationCollector collector = new NotificationCollector(hostAndPort);
-        Awaitility.await().until(() -> jedis.pubsubNumPat() > 0);
-        return collector;
-    }
 
     @TestTemplate
     public void generalEventsTest(Jedis jedis, HostAndPort hostAndPort) throws Exception {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/notifications/KeyspaceNotificationEdgeCasesTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/notifications/KeyspaceNotificationEdgeCasesTest.java
@@ -1,0 +1,108 @@
+package com.github.fppt.jedismock.comparisontests.notifications;
+
+import com.github.fppt.jedismock.comparisontests.ComparisonBase;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.params.ZAddParams;
+import redis.clients.jedis.params.ZRangeParams;
+
+import static com.github.fppt.jedismock.comparisontests.notifications.NotificationCollector.collectorFor;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Edge cases around which command variants publish which event, gathered while
+ * reviewing the type-class implementation: commands that report a different
+ * event depending on an option, commands whose source and destination are the
+ * same key, and writes whose result happens to equal what was already stored.
+ */
+@ExtendWith(ComparisonBase.class)
+public class KeyspaceNotificationEdgeCasesTest {
+
+    @TestTemplate
+    public void zaddWithIncrOptionPublishesZincr(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "Ez")) {
+            jedis.zadd("z", 1, "m");
+            //ZADD ... INCR is an increment, and is reported as one
+            jedis.zaddIncr("z", 5, "m", ZAddParams.zAddParams());
+            assertThat(events.next(2)).containsExactly(
+                    "__keyevent@0__:zadd -> z",
+                    "__keyevent@0__:zincr -> z");
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    @TestTemplate
+    public void movingAMemberOntoItsOwnSetPublishesNothing(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "Esg")) {
+            jedis.sadd("s", "m");
+            assertThat(events.next(1)).containsExactly("__keyevent@0__:sadd -> s");
+            //Source and destination are the same key: nothing changes
+            assertThat(jedis.smove("s", "s", "m")).isEqualTo(1L);
+            events.assertNoFurtherNotifications();
+            assertThat(jedis.smembers("s")).containsExactly("m");
+        }
+    }
+
+    @TestTemplate
+    public void rangestoreFromAMissingSourcePublishesDelForTheDestination(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "Ezg")) {
+            jedis.zadd("dest", 1, "m");
+            assertThat(events.next(1)).containsExactly("__keyevent@0__:zadd -> dest");
+            //An empty result removes the destination, which is a generic del
+            jedis.zrangestore("dest", "nosuchkey", ZRangeParams.zrangeParams(0, -1));
+            assertThat(events.next(1)).containsExactly("__keyevent@0__:del -> dest");
+            events.assertNoFurtherNotifications();
+            assertThat(jedis.exists("dest")).isFalse();
+        }
+    }
+
+    @TestTemplate
+    public void setrangeWritingTheSameBytesStillPublishes(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "E$")) {
+            jedis.set("k", "abc");
+            assertThat(events.next(1)).containsExactly("__keyevent@0__:set -> k");
+            //The stored value does not change, but the command still writes
+            jedis.setrange("k", 0, "abc");
+            assertThat(events.next(1)).containsExactly("__keyevent@0__:setrange -> k");
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    @TestTemplate
+    public void setrangeWithAnEmptyValuePublishesNothing(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "E$")) {
+            jedis.set("k", "abc");
+            assertThat(events.next(1)).containsExactly("__keyevent@0__:set -> k");
+            //An empty value writes nothing at all
+            jedis.setrange("k", 0, "");
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    @TestTemplate
+    public void appendOfAnEmptyValueStillPublishes(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "E$")) {
+            jedis.set("k", "abc");
+            assertThat(events.next(1)).containsExactly("__keyevent@0__:set -> k");
+            jedis.append("k", "");
+            assertThat(events.next(1)).containsExactly("__keyevent@0__:append -> k");
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    @TestTemplate
+    public void rotatingAListOntoItselfPublishesBothEnds(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "Elg")) {
+            jedis.rpush("l", "a", "b");
+            assertThat(events.next(1)).containsExactly("__keyevent@0__:rpush -> l");
+            //Source and destination are the same list
+            jedis.rpoplpush("l", "l");
+            assertThat(events.next(2)).containsExactly(
+                    "__keyevent@0__:lpush -> l",
+                    "__keyevent@0__:rpop -> l");
+            events.assertNoFurtherNotifications();
+        }
+    }
+}

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/notifications/ListKeyspaceNotificationsTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/notifications/ListKeyspaceNotificationsTest.java
@@ -1,0 +1,132 @@
+package com.github.fppt.jedismock.comparisontests.notifications;
+
+import com.github.fppt.jedismock.comparisontests.ComparisonBase;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.args.ListPosition;
+
+import static com.github.fppt.jedismock.comparisontests.notifications.NotificationCollector.collectorFor;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Keyspace notifications of the list ({@code l}) event class.
+ * <p>
+ * A multi-element push reports one event, not one per element, and the
+ * {@code X} variants report the same event as their unconditional forms.
+ * Emptying a list additionally reports a <em>generic</em> {@code del}.
+ */
+@ExtendWith(ComparisonBase.class)
+public class ListKeyspaceNotificationsTest {
+
+    @TestTemplate
+    public void pushCommandsPublishOneEventPerCommand(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "El")) {
+            jedis.rpush("L", "a", "b", "c");
+            jedis.lpush("L", "z");
+            jedis.lpushx("L", "y");
+            jedis.rpushx("L", "w");
+            //Neither X variant does anything to a missing key, so neither reports
+            jedis.lpushx("missing", "v");
+            jedis.rpushx("missing", "v");
+            assertThat(events.next(4)).containsExactly(
+                    "__keyevent@0__:rpush -> L",
+                    "__keyevent@0__:lpush -> L",
+                    "__keyevent@0__:lpush -> L",
+                    "__keyevent@0__:rpush -> L");
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    @TestTemplate
+    public void popCommandsPublishPopThenGenericDelWhenEmptied(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "Elg")) {
+            jedis.rpush("L", "a", "b");
+            jedis.lpop("L");
+            jedis.rpop("L");
+            assertThat(events.next(4)).containsExactly(
+                    "__keyevent@0__:rpush -> L",
+                    "__keyevent@0__:lpop -> L",
+                    //the second pop empties the list, which is a generic 'del'
+                    "__keyevent@0__:rpop -> L",
+                    "__keyevent@0__:del -> L");
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    @TestTemplate
+    public void blockingPopPublishesTheSamePopEvent(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "El")) {
+            jedis.rpush("B", "a", "b");
+            jedis.blpop(0, "B");
+            jedis.brpop(0, "B");
+            assertThat(events.next(3)).containsExactly(
+                    "__keyevent@0__:rpush -> B",
+                    "__keyevent@0__:lpop -> B",
+                    "__keyevent@0__:rpop -> B");
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    @TestTemplate
+    public void inPlaceMutationsPublishTheirOwnEvents(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "El")) {
+            jedis.rpush("L", "a", "b", "c");
+            jedis.linsert("L", ListPosition.BEFORE, "a", "q");
+            jedis.lset("L", 0, "w");
+            jedis.lrem("L", 0, "w");
+            jedis.ltrim("L", 0, 0);
+            assertThat(events.next(5)).containsExactly(
+                    "__keyevent@0__:rpush -> L",
+                    "__keyevent@0__:linsert -> L",
+                    "__keyevent@0__:lset -> L",
+                    "__keyevent@0__:lrem -> L",
+                    "__keyevent@0__:ltrim -> L");
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    @TestTemplate
+    public void rpoplpushPublishesDestinationPushBeforeSourcePop(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "Elg")) {
+            jedis.rpush("src", "a");
+            jedis.rpoplpush("src", "dst");
+            //Redis reports the push into the destination first, then the pop
+            //from the source, then the generic del for the emptied source
+            assertThat(events.next(4)).containsExactly(
+                    "__keyevent@0__:rpush -> src",
+                    "__keyevent@0__:lpush -> dst",
+                    "__keyevent@0__:rpop -> src",
+                    "__keyevent@0__:del -> src");
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    @TestTemplate
+    public void sortWithStorePublishesSortstoreForTheDestination(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "El")) {
+            jedis.rpush("unsorted", "3", "1", "2");
+            jedis.sort("unsorted", "sorted");
+            assertThat(events.next(2)).containsExactly(
+                    "__keyevent@0__:rpush -> unsorted",
+                    "__keyevent@0__:sortstore -> sorted");
+            //A SORT without STORE writes nothing, so reports nothing
+            jedis.sort("unsorted");
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    @TestTemplate
+    public void listClassAloneMasksOtherClasses(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        //Mirrors the upstream "we are able to mask events" test
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "KEl")) {
+            jedis.set("foo", "bar");
+            jedis.lpush("mylist", "a");
+            assertThat(events.next(2)).containsExactly(
+                    "__keyspace@0__:mylist -> lpush",
+                    "__keyevent@0__:lpush -> mylist");
+            events.assertNoFurtherNotifications();
+        }
+    }
+}

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/notifications/ListKeyspaceNotificationsTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/notifications/ListKeyspaceNotificationsTest.java
@@ -88,6 +88,31 @@ public class ListKeyspaceNotificationsTest {
     }
 
     @TestTemplate
+    public void trimmingNothingStillPublishesLtrim(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "Elg")) {
+            jedis.rpush("L", "a", "b", "c");
+            assertThat(events.next(1)).containsExactly("__keyevent@0__:rpush -> L");
+            //LTRIM reports unconditionally, even when the range keeps everything
+            jedis.ltrim("L", 0, -1);
+            assertThat(events.next(1)).containsExactly("__keyevent@0__:ltrim -> L");
+            //Whereas removing an absent element reports nothing
+            jedis.lrem("L", 0, "absent");
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    @TestTemplate
+    public void mutatingAMissingListPublishesNothing(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "Elg")) {
+            jedis.ltrim("nosuchlist", 0, -1);
+            jedis.lrem("nosuchlist", 0, "a");
+            jedis.lpop("nosuchlist");
+            jedis.rpop("nosuchlist");
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    @TestTemplate
     public void rpoplpushPublishesDestinationPushBeforeSourcePop(Jedis jedis, HostAndPort hostAndPort) throws Exception {
         try (NotificationCollector events = collectorFor(jedis, hostAndPort, "Elg")) {
             jedis.rpush("src", "a");

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/notifications/NewKeyKeyspaceNotificationsTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/notifications/NewKeyKeyspaceNotificationsTest.java
@@ -72,6 +72,44 @@ public class NewKeyKeyspaceNotificationsTest {
     }
 
     @TestTemplate
+    public void overwritingAnExpiredKeyPublishesExpiredThenNew(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        //A write that finds the key already expired must first report the
+        //expiry, and then treat the write as a creation
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "E$nx")) {
+            jedis.psetex("k", 50, "v");
+            assertThat(events.next(2)).containsExactly(
+                    "__keyevent@0__:new -> k",
+                    "__keyevent@0__:set -> k");
+            //Deliberately do not read the key while it expires
+            Thread.sleep(300);
+            jedis.set("k", "again");
+            assertThat(events.next(3)).containsExactly(
+                    "__keyevent@0__:expired -> k",
+                    "__keyevent@0__:new -> k",
+                    "__keyevent@0__:set -> k");
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    @TestTemplate
+    public void writingAFieldOfAnExpiredHashPublishesExpiredThenNew(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "Ehnx")) {
+            jedis.hset("h", "f", "v");
+            jedis.pexpire("h", 50);
+            assertThat(events.next(2)).containsExactly(
+                    "__keyevent@0__:new -> h",
+                    "__keyevent@0__:hset -> h");
+            Thread.sleep(300);
+            jedis.hset("h", "f", "again");
+            assertThat(events.next(3)).containsExactly(
+                    "__keyevent@0__:expired -> h",
+                    "__keyevent@0__:new -> h",
+                    "__keyevent@0__:hset -> h");
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    @TestTemplate
     public void newKeyClassIsNotPartOfTheAllAlias(Jedis jedis, HostAndPort hostAndPort) throws Exception {
         //'A' covers every class except K, E, n and m, so 'new' stays silent
         try (NotificationCollector events = collectorFor(jedis, hostAndPort, "EA")) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/notifications/NewKeyKeyspaceNotificationsTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/notifications/NewKeyKeyspaceNotificationsTest.java
@@ -1,0 +1,83 @@
+package com.github.fppt.jedismock.comparisontests.notifications;
+
+import com.github.fppt.jedismock.comparisontests.ComparisonBase;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.StreamEntryID;
+
+import java.util.Collections;
+
+import static com.github.fppt.jedismock.comparisontests.notifications.NotificationCollector.collectorFor;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Keyspace notifications of the new-key ({@code n}) event class: a single
+ * {@code new} event the first time a key comes into existence, whatever its
+ * type. Unlike the other classes it is not covered by the {@code A} alias.
+ */
+@ExtendWith(ComparisonBase.class)
+public class NewKeyKeyspaceNotificationsTest {
+
+    @TestTemplate
+    public void everyTypeOfCreationPublishesNewOnce(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "En")) {
+            jedis.set("k1", "v");
+            //A second write to an existing key is not a creation
+            jedis.set("k1", "w");
+            jedis.rpush("k2", "a");
+            jedis.rpush("k2", "b");
+            jedis.sadd("k3", "a");
+            jedis.hset("k4", "f", "v");
+            jedis.zadd("k5", 1, "a");
+            jedis.xadd("k6", new StreamEntryID(1, 1), Collections.singletonMap("f", "v"));
+            jedis.incr("k7");
+            assertThat(events.next(7)).containsExactly(
+                    "__keyevent@0__:new -> k1",
+                    "__keyevent@0__:new -> k2",
+                    "__keyevent@0__:new -> k3",
+                    "__keyevent@0__:new -> k4",
+                    "__keyevent@0__:new -> k5",
+                    "__keyevent@0__:new -> k6",
+                    "__keyevent@0__:new -> k7");
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    @TestTemplate
+    public void newIsPublishedBeforeTheTypeEvent(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "E$n")) {
+            jedis.set("k", "v");
+            jedis.set("k", "w");
+            assertThat(events.next(3)).containsExactly(
+                    "__keyevent@0__:new -> k",
+                    "__keyevent@0__:set -> k",
+                    "__keyevent@0__:set -> k");
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    @TestTemplate
+    public void recreatingAKeyPublishesNewAgain(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "En")) {
+            jedis.set("k", "v");
+            jedis.del("k");
+            jedis.set("k", "v");
+            assertThat(events.next(2)).containsExactly(
+                    "__keyevent@0__:new -> k",
+                    "__keyevent@0__:new -> k");
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    @TestTemplate
+    public void newKeyClassIsNotPartOfTheAllAlias(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        //'A' covers every class except K, E, n and m, so 'new' stays silent
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "EA")) {
+            jedis.set("k", "v");
+            assertThat(events.next(1)).containsExactly("__keyevent@0__:set -> k");
+            events.assertNoFurtherNotifications();
+        }
+    }
+}

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/notifications/NotificationCollector.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/notifications/NotificationCollector.java
@@ -1,0 +1,87 @@
+package com.github.fppt.jedismock.comparisontests.notifications;
+
+import org.testcontainers.shaded.org.awaitility.Awaitility;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPubSub;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Collects keyspace notifications in arrival order for the notification
+ * comparison tests. Subscribes to every {@code __keyspace@*__}/
+ * {@code __keyevent@*__} channel and records each message as
+ * {@code "<channel> -> <payload>"}, so a test can assert an exact sequence.
+ */
+public final class NotificationCollector implements AutoCloseable {
+
+    private static final String PARAM = "notify-keyspace-events";
+
+    private final Jedis client;
+    private final BlockingQueue<String> events = new LinkedBlockingQueue<>();
+    private final JedisPubSub subscriber;
+    private final ExecutorService service = Executors.newSingleThreadExecutor();
+    private final Future<?> future;
+
+    private NotificationCollector(HostAndPort hostAndPort) {
+        client = new Jedis(hostAndPort.getHost(), hostAndPort.getPort());
+        subscriber = new JedisPubSub() {
+            @Override
+            public void onPMessage(String pattern, String channel, String message) {
+                events.add(channel + " -> " + message);
+            }
+        };
+        future = service.submit(() -> client.psubscribe(subscriber, "__key*@*__:*"));
+    }
+
+    /**
+     * Clears the key space, enables the given event flags and starts
+     * collecting, returning only once the subscription is established.
+     */
+    public static NotificationCollector collectorFor(Jedis jedis, HostAndPort hostAndPort, String flags) {
+        jedis.flushAll();
+        jedis.configSet(PARAM, flags);
+        NotificationCollector collector = new NotificationCollector(hostAndPort);
+        Awaitility.await().until(() -> jedis.pubsubNumPat() > 0);
+        return collector;
+    }
+
+    /** Waits for exactly {@code count} notifications and returns them in arrival order. */
+    public List<String> next(int count) throws InterruptedException {
+        List<String> received = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            String event = events.poll(10, TimeUnit.SECONDS);
+            assertThat(event).as("notification %d of %d (got %s)", i + 1, count, received).isNotNull();
+            received.add(event);
+        }
+        return received;
+    }
+
+    public void assertNoFurtherNotifications() throws InterruptedException {
+        assertThat(events.poll(300, TimeUnit.MILLISECONDS)).isNull();
+    }
+
+    @Override
+    public void close() throws Exception {
+        try {
+            subscriber.punsubscribe();
+            future.get(5, TimeUnit.SECONDS);
+        } catch (TimeoutException e) {
+            //Fall through to the forced disconnect below.
+        } finally {
+            service.shutdownNow();
+            client.disconnect();
+            client.close();
+        }
+    }
+}

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/notifications/StreamKeyspaceNotificationsTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/notifications/StreamKeyspaceNotificationsTest.java
@@ -1,0 +1,78 @@
+package com.github.fppt.jedismock.comparisontests.notifications;
+
+import com.github.fppt.jedismock.comparisontests.ComparisonBase;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.StreamEntryID;
+import redis.clients.jedis.params.XAddParams;
+
+import java.util.Collections;
+
+import static com.github.fppt.jedismock.comparisontests.notifications.NotificationCollector.collectorFor;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Keyspace notifications of the stream ({@code t}) event class, for the
+ * commands the mock implements. The consumer-group commands ({@code XGROUP},
+ * {@code XREADGROUP}, {@code XCLAIM}, {@code XSETID}) are not supported at
+ * all, so their events — {@code xgroup-create} and friends — are out of scope.
+ */
+@ExtendWith(ComparisonBase.class)
+public class StreamKeyspaceNotificationsTest {
+
+    @TestTemplate
+    public void streamWritesPublishTheirEvents(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "Et")) {
+            jedis.xadd("st", new StreamEntryID(1, 1), Collections.singletonMap("f", "v"));
+            jedis.xadd("st", new StreamEntryID(2, 2), Collections.singletonMap("f", "v"));
+            jedis.xdel("st", new StreamEntryID(1, 1));
+            jedis.xtrim("st", 0, false);
+            assertThat(events.next(4)).containsExactly(
+                    "__keyevent@0__:xadd -> st",
+                    "__keyevent@0__:xadd -> st",
+                    "__keyevent@0__:xdel -> st",
+                    "__keyevent@0__:xtrim -> st");
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    @TestTemplate
+    public void bothChannelFamiliesCarryStreamEvents(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "KEt")) {
+            jedis.xadd("st", new StreamEntryID(1, 1), Collections.singletonMap("f", "v"));
+            assertThat(events.next(2)).containsExactly(
+                    "__keyspace@0__:st -> xadd",
+                    "__keyevent@0__:xadd -> st");
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    @TestTemplate
+    public void addWithTrimmingPublishesAddThenTrim(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "Et")) {
+            jedis.xadd("st", new StreamEntryID(1, 1), Collections.singletonMap("f", "v"));
+            //An XADD that also trims reports both events
+            jedis.xadd("st", XAddParams.xAddParams().id(new StreamEntryID(2, 2)).maxLen(1),
+                    Collections.singletonMap("f", "v"));
+            assertThat(events.next(3)).containsExactly(
+                    "__keyevent@0__:xadd -> st",
+                    "__keyevent@0__:xadd -> st",
+                    "__keyevent@0__:xtrim -> st");
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    @TestTemplate
+    public void commandsThatChangeNothingAreSilent(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "Et")) {
+            jedis.xadd("st", new StreamEntryID(1, 1), Collections.singletonMap("f", "v"));
+            assertThat(events.next(1)).containsExactly("__keyevent@0__:xadd -> st");
+            //Deleting an absent id and a no-op trim change nothing
+            jedis.xdel("st", new StreamEntryID(9, 9));
+            jedis.xtrim("st", 100, false);
+            events.assertNoFurtherNotifications();
+        }
+    }
+}

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/notifications/StringKeyspaceNotificationsTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/notifications/StringKeyspaceNotificationsTest.java
@@ -1,0 +1,132 @@
+package com.github.fppt.jedismock.comparisontests.notifications;
+
+import com.github.fppt.jedismock.comparisontests.ComparisonBase;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.params.SetParams;
+
+import static com.github.fppt.jedismock.comparisontests.notifications.NotificationCollector.collectorFor;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Keyspace notifications of the string ({@code $}) event class.
+ * <p>
+ * The event name is not the command name: every flavour of assignment reports
+ * {@code set}, and all four of {@code INCR}, {@code INCRBY}, {@code DECR} and
+ * {@code DECRBY} report {@code incrby}.
+ */
+@ExtendWith(ComparisonBase.class)
+public class StringKeyspaceNotificationsTest {
+
+    @TestTemplate
+    public void assignmentCommandsPublishSet(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "E$")) {
+            jedis.set("s1", "v");
+            jedis.setnx("s2", "v");
+            jedis.mset("m1", "1", "m2", "2");
+            jedis.msetnx("m3", "1", "m4", "2");
+            jedis.getSet("s1", "w");
+            jedis.setex("sx", 100, "v");
+            assertThat(events.next(8)).containsExactly(
+                    "__keyevent@0__:set -> s1",
+                    "__keyevent@0__:set -> s2",
+                    "__keyevent@0__:set -> m1",
+                    "__keyevent@0__:set -> m2",
+                    "__keyevent@0__:set -> m3",
+                    "__keyevent@0__:set -> m4",
+                    "__keyevent@0__:set -> s1",
+                    "__keyevent@0__:set -> sx");
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    @TestTemplate
+    public void bothChannelFamiliesCarryTheSetEvent(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "KE$")) {
+            jedis.set("foo", "bar");
+            assertThat(events.next(2)).containsExactly(
+                    "__keyspace@0__:foo -> set",
+                    "__keyevent@0__:set -> foo");
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    @TestTemplate
+    public void settingWithExpirationPublishesSetThenExpire(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        //Both classes enabled: the string 'set' is reported before the generic 'expire'
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "E$g")) {
+            jedis.set("withex", "v", SetParams.setParams().ex(100));
+            jedis.setex("sx", 100, "v");
+            jedis.psetex("px", 100_000, "v");
+            assertThat(events.next(6)).containsExactly(
+                    "__keyevent@0__:set -> withex",
+                    "__keyevent@0__:expire -> withex",
+                    "__keyevent@0__:set -> sx",
+                    "__keyevent@0__:expire -> sx",
+                    "__keyevent@0__:set -> px",
+                    "__keyevent@0__:expire -> px");
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    @TestTemplate
+    public void appendAndSetrangePublishTheirOwnEvents(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "E$")) {
+            jedis.append("a1", "abc");
+            jedis.append("a1", "def");
+            jedis.setrange("a1", 0, "z");
+            assertThat(events.next(3)).containsExactly(
+                    "__keyevent@0__:append -> a1",
+                    "__keyevent@0__:append -> a1",
+                    "__keyevent@0__:setrange -> a1");
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    @TestTemplate
+    public void allIntegerIncrementsPublishIncrby(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "E$")) {
+            //Redis reports 'incrby' for the decrementing variants too
+            jedis.incr("c1");
+            jedis.incrBy("c1", 5);
+            jedis.decr("c1");
+            jedis.decrBy("c1", 2);
+            jedis.incrByFloat("f1", 1.5);
+            assertThat(events.next(5)).containsExactly(
+                    "__keyevent@0__:incrby -> c1",
+                    "__keyevent@0__:incrby -> c1",
+                    "__keyevent@0__:incrby -> c1",
+                    "__keyevent@0__:incrby -> c1",
+                    "__keyevent@0__:incrbyfloat -> f1");
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    @TestTemplate
+    public void conditionalAssignmentsThatDoNothingAreSilent(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "E$")) {
+            jedis.set("exists", "v");
+            assertThat(events.next(1)).containsExactly("__keyevent@0__:set -> exists");
+            //None of these change anything, so none are reported
+            jedis.setnx("exists", "other");
+            jedis.msetnx("exists", "other", "fresh", "v");
+            jedis.set("missing", "v", SetParams.setParams().xx());
+            jedis.set("exists", "v", SetParams.setParams().nx());
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    @TestTemplate
+    public void stringClassAloneMasksOtherClasses(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "E$")) {
+            jedis.set("masked", "v");
+            assertThat(events.next(1)).containsExactly("__keyevent@0__:set -> masked");
+            //DEL and EXPIRE are generic, which is not enabled
+            jedis.expire("masked", 100);
+            jedis.del("masked");
+            events.assertNoFurtherNotifications();
+        }
+    }
+}

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/transactions/WatchInPlaceMutationTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/transactions/WatchInPlaceMutationTest.java
@@ -1,0 +1,88 @@
+package com.github.fppt.jedismock.comparisontests.transactions;
+
+import com.github.fppt.jedismock.comparisontests.ComparisonBase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.Transaction;
+import redis.clients.jedis.args.ListPosition;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Commands that mutate a list or stream in place — rather than replacing the
+ * value — must still count as touching the key, so a transaction watching it
+ * is aborted. A command that turns out to change nothing must not abort one.
+ */
+@ExtendWith(ComparisonBase.class)
+public class WatchInPlaceMutationTest {
+
+    private static final String KEY = "watched_list";
+
+    private Jedis anotherJedis;
+
+    @BeforeEach
+    public void setup(Jedis jedis, HostAndPort hostAndPort) {
+        jedis.flushAll();
+        anotherJedis = new Jedis(hostAndPort.getHost(), hostAndPort.getPort());
+    }
+
+    @AfterEach
+    public void tearDown() {
+        anotherJedis.close();
+    }
+
+    /** @return the EXEC result: null when the transaction was aborted. */
+    private List<Object> execAfterInterference(Jedis jedis, Consumer<Jedis> interference) {
+        jedis.watch(KEY);
+        interference.accept(anotherJedis);
+        Transaction transaction = jedis.multi();
+        transaction.set("sentinel", "written");
+        return transaction.exec();
+    }
+
+    @TestTemplate
+    public void inPlaceListMutationsAbortAWatchingTransaction(Jedis jedis) {
+        jedis.rpush(KEY, "a", "b", "c");
+        assertThat(execAfterInterference(jedis, other -> other.lset(KEY, 0, "z")))
+                .as("LSET must abort").isNull();
+
+        jedis.del(KEY);
+        jedis.rpush(KEY, "a", "b", "c");
+        assertThat(execAfterInterference(jedis, other -> other.linsert(KEY, ListPosition.BEFORE, "a", "q")))
+                .as("LINSERT must abort").isNull();
+
+        jedis.del(KEY);
+        jedis.rpush(KEY, "a", "b", "c");
+        assertThat(execAfterInterference(jedis, other -> other.lrem(KEY, 0, "a")))
+                .as("LREM must abort").isNull();
+
+        jedis.del(KEY);
+        jedis.rpush(KEY, "a", "b", "c");
+        assertThat(execAfterInterference(jedis, other -> other.ltrim(KEY, 0, 1)))
+                .as("LTRIM must abort").isNull();
+    }
+
+    @TestTemplate
+    public void removingAnAbsentElementDoesNotAbortAWatchingTransaction(Jedis jedis) {
+        jedis.rpush(KEY, "a", "b", "c");
+        //LREM only counts as touching the key when it removed something
+        assertThat(execAfterInterference(jedis, other -> other.lrem(KEY, 0, "absent")))
+                .as("no-op LREM must not abort").isNotNull();
+    }
+
+    @TestTemplate
+    public void trimmingNothingStillAbortsAWatchingTransaction(Jedis jedis) {
+        jedis.rpush(KEY, "a", "b", "c");
+        //Unlike LREM, LTRIM signals the key as modified unconditionally, even
+        //when the range covers the whole list and nothing is removed
+        assertThat(execAfterInterference(jedis, other -> other.ltrim(KEY, 0, -1)))
+                .as("no-op LTRIM aborts anyway").isNull();
+    }
+}

--- a/src/test/java/com/github/fppt/jedismock/operations/scripting/ScriptErrorReplyFramingTest.java
+++ b/src/test/java/com/github/fppt/jedismock/operations/scripting/ScriptErrorReplyFramingTest.java
@@ -75,7 +75,7 @@ class ScriptErrorReplyFramingTest {
                 readExactly(in, reply, length + 2); // payload + trailing CRLF
             }
         }
-        return new String(reply.toByteArray(), StandardCharsets.UTF_8);
+        return reply.toString(StandardCharsets.UTF_8);
     }
 
     private static int readByte(InputStream in) throws IOException {


### PR DESCRIPTION
Adds the type-specific keyspace-notification event classes, completing the bulk of #406. Builds on #811, which delivered the configuration parameter, the two channel families and the generic (`g`) and expired (`x`) classes.

## What this adds

| Flag | Class | Events |
| --- | --- | --- |
| `$` | string | `set`, `append`, `setrange`, `incrby`, `incrbyfloat` |
| `l` | list | `lpush`, `rpush`, `lpop`, `rpop`, `linsert`, `lset`, `lrem`, `ltrim`, `sortstore` |
| `s` | set | `sadd`, `srem`, `spop`, `sinterstore`, `sunionstore`, `sdiffstore` |
| `h` | hash | `hset`, `hdel`, `hincrby`, `hincrbyfloat` |
| `z` | sorted set | `zadd`, `zincr`, `zrem`, `zremrangeby{score,rank,lex}`, `z{union,inter,diff}store`, `zrangestore`, `zpopmin`, `zpopmax` |
| `t` | stream | `xadd`, `xtrim`, `xdel` |
| `n` | new key | `new` |

Together with #811 that covers every class Jedis-Mock can support. The README gains a "Keyspace notifications" section documenting the flags, the events, and the remaining limitations.

## How the event names were established

Every name and ordering was derived by probing `redis:7.4-alpine` and then pinned with a comparison test, rather than inferred from the command name. That mattered — the following are all counter-intuitive and all verified:

* `DECR` and `DECRBY` report **`incrby`**, not `decrby`.
* `ZINCRBY` reports **`zincr`**; so does `ZADD … INCR`.
* `UNLINK` reports **`del`**, not `unlink`.
* `HSETNX` and `HMSET` both report **`hset`**.
* A multi-element push reports **one** event, not one per element; `LPUSHX`/`RPUSHX` report the same event as their unconditional forms.
* Emptying a container reports the **generic** `del` in addition to the type's own event — the `del` is not the container's class.
* `new` precedes the type's own event, and is **not** covered by the `A` alias.
* Orderings are not consistent between commands: `RPOPLPUSH` reports the destination's `lpush` *before* the source's `rpop`, whereas `SMOVE` reports the source's `srem` **and the `del` for the set it emptied** before the destination's `sadd`.
* `XCLAIM`/`XAUTOCLAIM` publish no event of their own in 7.4 — only `xgroup-createconsumer`, and only for a consumer that did not exist.

## Bugs found while self-reviewing this branch

Each was first reproduced as a comparison test that fails against Jedis-Mock and passes against real Redis:

1. **`ZADD key INCR score member` reported `zadd`** instead of `zincr`.
2. **`SMOVE key key member` destroyed and recreated the set.** Redis short-circuits when source and destination are the same key and simply reports membership; the mock ran `SREM` then `SADD`, so a single-member set was deleted and recreated (and published `srem`/`del`/`sadd`). This was a **data-correctness bug predating this branch**, not only a notification one.
3. **`SETRANGE` writing identical bytes published nothing** — Redis writes, and reports, whenever the value argument is non-empty.
4. **`ZRANGESTORE` from a missing source did not publish `del`** for a destination that existed; the early-return path bypassed the notification.
5. **A no-op `LTRIM` published nothing and did not dirty the key for `WATCH`.** Unlike `LREM`, Redis signals `LTRIM` as a modification unconditionally, even when the range covers the whole list.

Three further edge cases turned out to already behave correctly — an empty-value `SETRANGE` (silent), an empty-value `APPEND` (reports), and `RPOPLPUSH` rotating a list onto itself — and their tests are kept as regression guards.

## Reviewer note: `WATCH` semantics change

Six commands that mutate a value in place rather than replacing it — `LINSERT`, `LSET`, `LREM`, `LTRIM`, `XDEL`, `XTRIM` — never marked their key as modified, so a transaction watching that key was **not** aborted. Publishing notifications required fixing that, so this branch changes `WATCH` behaviour for those commands. It is a fix (it matches real Redis), but it is worth reviewing deliberately rather than as a side effect. `WatchInPlaceMutationTest` covers both directions: real mutations abort a watching transaction, a no-op `LREM` does not, and a no-op `LTRIM` does.

## Testing

* **59 comparison tests** in `comparisontests/notifications`, each executed against both Jedis-Mock and real Redis, asserting exact event *sequences* including the keyspace/keyevent split, class masking, cross-database delivery and empty-container `del`.
* **12 upstream keyspace tests in `unit/pubsub.tcl` now run and pass** (previously all disabled): the `KA`/`EA`/`KEA` trio, event masking, general, list, set, zset, hash, triggered expiry, CONFIG flag round-tripping and new-key.
* Full Java suite and the whole native-test matrix green.

## Still out of scope

Four upstream tests remain disabled, each with the reason in a comment beside it:

* **`expired events (background expire)`** — Jedis-Mock expires keys lazily, so a key nobody touches produces its `expired` event later than a real server would. An active-expiry cycle is the natural follow-up.
* **`expired event (Expiration time is already expired)`** — an expiration set in the past reports `del` on Redis and `expired` on Valkey; this follows Redis, matching the container the comparison tests run against.
* **`evicted events`** — there is no `maxmemory` model, so nothing is ever evicted.
* **`stream events test`** — it drives `XGROUP`/`XREADGROUP`/`XCLAIM`/`XAUTOCLAIM`, which Jedis-Mock does not implement at all, so their `xgroup-*` events cannot exist.

Also unimplemented: the `m` (key-miss) and `d` (module) classes, and `expired` from a `TTL`/`PTTL` lookup on an already-expired key (the event is published from the value-access path).

## Possible follow-up

The "type event, then generic `del` if the container is now gone" logic is repeated at eight call sites using three different existence checks (`list.isEmpty()`, `set.isEmpty()`, `!base().exists(key)`), which disagree about which of them deletes the key. Three of the five bugs above lived in that inconsistency. Consolidating it behind a single helper on `RedisBase` looks worthwhile, with one trap to watch: `exists()` runs `verifyKey`, which can itself publish `expired`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
