### PR TITLE
getex support

### DIFF
--- a/native_tests/linux/tests/unit/expire.tcl
+++ b/native_tests/linux/tests/unit/expire.tcl
@@ -253,17 +253,17 @@ start_server {tags {"expire"}} {
         set e
     } {ERR invalid expire time in 'set' command}
 
-    #test {GETEX with big integer should report an error} {
-    #    r set foo bar
-    #    catch {r GETEX foo EX 10000000000000000} e
-    #    set e
-    #} {ERR invalid expire time in 'getex' command}
+    test {GETEX with big integer should report an error} {
+        r set foo bar
+        catch {r GETEX foo EX 10000000000000000} e
+        set e
+    } {ERR invalid expire time in 'getex' command}
 
-    #test {GETEX with smallest integer should report an error} {
-    #    r set foo bar
-    #    catch {r GETEX foo EX -9999999999999999} e
-    #    set e
-    #} {ERR invalid expire time in 'getex' command}
+    test {GETEX with smallest integer should report an error} {
+        r set foo bar
+        catch {r GETEX foo EX -9999999999999999} e
+        set e
+    } {ERR invalid expire time in 'getex' command}
 
     test {EXPIRE with big integer overflows when converted to milliseconds} {
         r set foo bar
@@ -615,11 +615,11 @@ start_server {tags {"expire"}} {
     #    assert {$ttl <= 98 && $ttl > 90}
     #} {} {needs:debug}
 
-    #test {GETEX use of PERSIST option should remove TTL} {
-    #   r set foo bar EX 100
-    #   r getex foo PERSIST
-    #   r ttl foo
-    #} {-1}
+    test {GETEX use of PERSIST option should remove TTL} {
+       r set foo bar EX 100
+       r getex foo PERSIST
+       r ttl foo
+    } {-1}
 
     #test {GETEX use of PERSIST option should remove TTL after loadaof} {
     #   r config set appendonly yes

--- a/src/main/java/com/github/fppt/jedismock/operations/strings/GetEx.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/strings/GetEx.java
@@ -1,0 +1,143 @@
+package com.github.fppt.jedismock.operations.strings;
+
+import com.github.fppt.jedismock.datastructures.Slice;
+import com.github.fppt.jedismock.operations.AbstractRedisOperation;
+import com.github.fppt.jedismock.operations.RedisCommand;
+import com.github.fppt.jedismock.server.Response;
+import com.github.fppt.jedismock.storage.KeyspaceEvent;
+import com.github.fppt.jedismock.storage.RedisBase;
+
+import java.util.List;
+
+/**
+ * {@code GETEX key [EX seconds | PX milliseconds | EXAT unix-time-seconds |
+ * PXAT unix-time-milliseconds | PERSIST]}: a GET that may also change the
+ * key's expiration, and nothing else — the value itself is never written.
+ * <p>
+ * The order in which failures are reported follows real Redis and is
+ * observable: the option is parsed first, so a syntax error is reported even
+ * for a missing key or one of the wrong type; the expiration value, in
+ * contrast, is only validated after the key has been found to exist and to
+ * hold a string, so {@code GETEX missing EX 0} replies nil rather than
+ * erroring.
+ */
+@RedisCommand("getex")
+class GetEx extends AbstractRedisOperation {
+
+    GetEx(RedisBase base, List<Slice> params) {
+        super(base, params);
+    }
+
+    @Override
+    protected int minArgs() {
+        return 1;
+    }
+
+    /**
+     * The mutually exclusive expiration options. Repeating the <em>same</em>
+     * option is accepted (the last value wins), just as in Redis's own
+     * argument parser; mixing two different ones is a syntax error.
+     */
+    private enum Option {
+        EX(true, false),
+        PX(false, false),
+        EXAT(true, true),
+        PXAT(false, true),
+        PERSIST(false, false);
+
+        private final boolean seconds;
+        private final boolean absolute;
+
+        Option(boolean seconds, boolean absolute) {
+            this.seconds = seconds;
+            this.absolute = absolute;
+        }
+
+        static Option of(String name) {
+            for (Option option : values()) {
+                if (option.name().equalsIgnoreCase(name)) {
+                    return option;
+                }
+            }
+            return null;
+        }
+    }
+
+    protected Slice response() {
+        Slice key = params().get(0);
+        Option option = null;
+        Slice time = null;
+        for (int i = 1; i < params().size(); i++) {
+            Option parsed = Option.of(params().get(i).toString());
+            if (parsed == null || option != null && option != parsed) {
+                return Response.error("ERR syntax error");
+            }
+            if (parsed != Option.PERSIST) {
+                if (i + 1 >= params().size()) {
+                    return Response.error("ERR syntax error");
+                }
+                time = params().get(++i);
+            }
+            option = parsed;
+        }
+
+        //Raises WRONGTYPE for a non-string key, which outranks any bad expiration
+        Slice value = base().getSlice(key);
+        if (value == null) {
+            return Response.NULL;
+        }
+
+        if (time == null) {
+            if (option == Option.PERSIST && base().setDeadline(key, -1) == 1) {
+                base().notifyKeyspaceEvent(KeyspaceEvent.PERSIST, key);
+            }
+            return Response.bulkString(value);
+        }
+
+        long deadline;
+        try {
+            deadline = deadline(option, time);
+        } catch (IllegalArgumentException e) {
+            return Response.error(e.getMessage());
+        }
+        if (option.absolute && deadline <= base().getClock().millis()) {
+            //An absolute deadline that has already passed drops the key straight
+            //away, and is reported as a 'del' rather than an 'expired'
+            base().deleteValue(key);
+            base().notifyKeyspaceEvent(KeyspaceEvent.DEL, key);
+        } else {
+            base().setDeadline(key, deadline);
+            base().notifyKeyspaceEvent(KeyspaceEvent.EXPIRE, key);
+        }
+        return Response.bulkString(value);
+    }
+
+    /** The absolute deadline in milliseconds, rejecting values Redis refuses. */
+    private long deadline(Option option, Slice time) {
+        long value;
+        try {
+            value = Long.parseLong(time.toString());
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("ERR value is not an integer or out of range");
+        }
+        //A non-positive expiration is out of range for every unit, absolute ones
+        //included, and seconds are rejected once they overflow milliseconds
+        if (value <= 0 || option.seconds && value > Long.MAX_VALUE / 1000) {
+            throw invalidExpireTime();
+        }
+        long millis = option.seconds ? value * 1000 : value;
+        if (option.absolute) {
+            return millis;
+        }
+        long now = base().getClock().millis();
+        if (millis >= Long.MAX_VALUE - now) {
+            throw invalidExpireTime();
+        }
+        return millis + now;
+    }
+
+    private IllegalArgumentException invalidExpireTime() {
+        return new IllegalArgumentException(
+                String.format("ERR invalid expire time in '%s' command", self().value()));
+    }
+}

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/notifications/GenericKeyspaceNotificationsTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/notifications/GenericKeyspaceNotificationsTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.testcontainers.shaded.org.awaitility.Awaitility;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.Jedis;
+import redis.clients.jedis.params.GetExParams;
 import redis.clients.jedis.params.SetParams;
 
 import static com.github.fppt.jedismock.comparisontests.notifications.NotificationCollector.collectorFor;
@@ -153,8 +154,60 @@ public class GenericKeyspaceNotificationsTest {
         }
     }
 
-    //GETEX is not implemented by the mock at all, so its expire/persist events
-    //are out of scope here; add a case once the command itself is supported.
+    @TestTemplate
+    public void getexPublishesExpirePersistOrDelete(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        //GETEX reports only what it did to the expiration, and always as a
+        //generic event -- never the string 'set', despite being a write command
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "KEg")) {
+            jedis.set("gx", "v");
+            jedis.getEx("gx", GetExParams.getExParams().ex(100));
+            jedis.getEx("gx", GetExParams.getExParams().persist());
+            jedis.getEx("gx", GetExParams.getExParams().exAt(1));
+            assertThat(events.next(6)).containsExactly(
+                    "__keyspace@0__:gx -> expire",
+                    "__keyevent@0__:expire -> gx",
+                    "__keyspace@0__:gx -> persist",
+                    "__keyevent@0__:persist -> gx",
+                    //An absolute deadline in the past deletes the key: a 'del'
+                    "__keyspace@0__:gx -> del",
+                    "__keyevent@0__:del -> gx");
+            events.assertNoFurtherNotifications();
+            assertThat(jedis.exists("gx")).isFalse();
+        }
+    }
+
+    @TestTemplate
+    public void getexIsSilentWhenItChangesNoExpiration(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "Egx$n")) {
+            jedis.set("gx", "v", SetParams.setParams().ex(100));
+            assertThat(events.next(3)).containsExactly(
+                    "__keyevent@0__:new -> gx",
+                    "__keyevent@0__:set -> gx",
+                    "__keyevent@0__:expire -> gx");
+            //No option at all: a plain read, so nothing is published
+            jedis.getEx("gx", GetExParams.getExParams());
+            jedis.persist("gx");
+            assertThat(events.next(1)).containsExactly("__keyevent@0__:persist -> gx");
+            //PERSIST with no TTL left to remove, and GETEX on a missing key
+            jedis.getEx("gx", GetExParams.getExParams().persist());
+            jedis.getEx("nosuchkey", GetExParams.getExParams().ex(100));
+            jedis.getEx("nosuchkey", GetExParams.getExParams().exAt(1));
+            events.assertNoFurtherNotifications();
+        }
+    }
+
+    @TestTemplate
+    public void getexEventsBelongToTheGenericClassAlone(Jedis jedis, HostAndPort hostAndPort) throws Exception {
+        try (NotificationCollector events = collectorFor(jedis, hostAndPort, "E$")) {
+            jedis.set("gx", "v");
+            assertThat(events.next(1)).containsExactly("__keyevent@0__:set -> gx");
+            //Under the string class alone none of GETEX's events get through
+            jedis.getEx("gx", GetExParams.getExParams().ex(100));
+            jedis.getEx("gx", GetExParams.getExParams().persist());
+            jedis.getEx("gx", GetExParams.getExParams().pxAt(1));
+            events.assertNoFurtherNotifications();
+        }
+    }
 
     @TestTemplate
     public void settingWithExpirationPublishesGenericExpire(Jedis jedis, HostAndPort hostAndPort) throws Exception {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/strings/GetExTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/strings/GetExTest.java
@@ -1,0 +1,304 @@
+package com.github.fppt.jedismock.comparisontests.strings;
+
+import com.github.fppt.jedismock.comparisontests.ComparisonBase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.Protocol;
+import redis.clients.jedis.exceptions.JedisDataException;
+import redis.clients.jedis.params.GetExParams;
+import redis.clients.jedis.params.SetParams;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * GETEX: a GET that may also change the key's expiration.
+ * <p>
+ * The option is parsed before anything else, so a syntax error is reported
+ * even for a missing key or a key of the wrong type; conversely an out-of-range
+ * expiration is only reported once the key has been found to exist and to be a
+ * string. Nothing but the expiration is touched — the value is never written,
+ * and without an option the TTL is left exactly as it was.
+ */
+@ExtendWith(ComparisonBase.class)
+public class GetExTest {
+
+    private static final String INVALID_EXPIRE = "ERR invalid expire time in 'getex' command";
+    private static final String NOT_AN_INTEGER = "ERR value is not an integer or out of range";
+    private static final String SYNTAX_ERROR = "ERR syntax error";
+
+    @BeforeEach
+    public void setUp(Jedis jedis) {
+        jedis.flushAll();
+    }
+
+    /** Sends GETEX verbatim, for the cases Jedis's typed API cannot express. */
+    private static Object getex(Jedis jedis, String... args) {
+        return jedis.sendCommand(Protocol.Command.GETEX, args);
+    }
+
+    private static String getexString(Jedis jedis, String... args) {
+        Object reply = getex(jedis, args);
+        return reply == null ? null : new String((byte[]) reply);
+    }
+
+    @TestTemplate
+    public void documentationExample(Jedis jedis) {
+        assertThat(jedis.set("mykey", "Hello")).isEqualTo("OK");
+        assertThat(jedis.getEx("mykey", GetExParams.getExParams())).isEqualTo("Hello");
+        assertThat(jedis.ttl("mykey")).isEqualTo(-1L);
+        assertThat(jedis.getEx("mykey", GetExParams.getExParams().ex(60))).isEqualTo("Hello");
+        assertThat(jedis.ttl("mykey")).isEqualTo(60L);
+    }
+
+    @TestTemplate
+    public void withoutAnOptionTheTtlIsLeftAlone(Jedis jedis) {
+        jedis.set("foo", "bar", SetParams.setParams().ex(100));
+        assertThat(jedis.getEx("foo", GetExParams.getExParams())).isEqualTo("bar");
+        assertThat(jedis.ttl("foo")).isBetween(90L, 100L);
+    }
+
+    @TestTemplate
+    public void theValueIsNeverModified(Jedis jedis) {
+        jedis.set("foo", "bar");
+        jedis.getEx("foo", GetExParams.getExParams().ex(100));
+        assertThat(jedis.get("foo")).isEqualTo("bar");
+    }
+
+    @TestTemplate
+    public void missingKeyReturnsNullAndIsNotCreated(Jedis jedis) {
+        assertThat(jedis.getEx("nosuchkey", GetExParams.getExParams())).isNull();
+        assertThat(jedis.getEx("nosuchkey", GetExParams.getExParams().ex(100))).isNull();
+        assertThat(jedis.getEx("nosuchkey", GetExParams.getExParams().persist())).isNull();
+        assertThat(jedis.exists("nosuchkey")).isFalse();
+    }
+
+    @TestTemplate
+    public void pxSetsAMillisecondTtl(Jedis jedis) {
+        jedis.set("foo", "bar");
+        assertThat(jedis.getEx("foo", GetExParams.getExParams().px(100_000))).isEqualTo("bar");
+        assertThat(jedis.pttl("foo")).isBetween(90_000L, 100_000L);
+    }
+
+    @TestTemplate
+    public void exAtSetsAnAbsoluteTtl(Jedis jedis) {
+        jedis.set("foo", "bar");
+        long deadline = System.currentTimeMillis() / 1000 + 100;
+        assertThat(jedis.getEx("foo", GetExParams.getExParams().exAt(deadline))).isEqualTo("bar");
+        assertThat(jedis.ttl("foo")).isBetween(90L, 100L);
+        assertThat(jedis.expireTime("foo")).isEqualTo(deadline);
+    }
+
+    @TestTemplate
+    public void pxAtSetsAnAbsoluteTtl(Jedis jedis) {
+        jedis.set("foo", "bar");
+        long deadline = System.currentTimeMillis() + 100_000;
+        assertThat(jedis.getEx("foo", GetExParams.getExParams().pxAt(deadline))).isEqualTo("bar");
+        assertThat(jedis.pttl("foo")).isBetween(90_000L, 100_000L);
+        assertThat(jedis.pexpireTime("foo")).isEqualTo(deadline);
+    }
+
+    @TestTemplate
+    public void anExistingTtlIsReplacedRatherThanShortened(Jedis jedis) {
+        jedis.set("foo", "bar", SetParams.setParams().ex(10));
+        jedis.getEx("foo", GetExParams.getExParams().ex(1000));
+        assertThat(jedis.ttl("foo")).isBetween(990L, 1000L);
+        jedis.getEx("foo", GetExParams.getExParams().ex(10));
+        assertThat(jedis.ttl("foo")).isBetween(1L, 10L);
+    }
+
+    //Equivalent of the commented-out expire.tcl test
+    //{GETEX use of PERSIST option should remove TTL}
+    @TestTemplate
+    public void persistRemovesTtl(Jedis jedis) {
+        jedis.set("foo", "bar", SetParams.setParams().ex(100));
+        assertThat(jedis.getEx("foo", GetExParams.getExParams().persist())).isEqualTo("bar");
+        assertThat(jedis.ttl("foo")).isEqualTo(-1L);
+    }
+
+    @TestTemplate
+    public void persistOnAKeyWithoutTtlIsHarmless(Jedis jedis) {
+        jedis.set("foo", "bar");
+        assertThat(jedis.getEx("foo", GetExParams.getExParams().persist())).isEqualTo("bar");
+        assertThat(jedis.ttl("foo")).isEqualTo(-1L);
+        assertThat(jedis.exists("foo")).isTrue();
+    }
+
+    @TestTemplate
+    public void exAtInThePastDeletesTheKey(Jedis jedis) {
+        jedis.set("foo", "bar");
+        //The value is still returned, and only then is the key dropped
+        assertThat(jedis.getEx("foo", GetExParams.getExParams().exAt(1))).isEqualTo("bar");
+        assertThat(jedis.exists("foo")).isFalse();
+    }
+
+    @TestTemplate
+    public void pxAtInThePastDeletesTheKey(Jedis jedis) {
+        jedis.set("foo", "bar");
+        assertThat(jedis.getEx("foo", GetExParams.getExParams().pxAt(1))).isEqualTo("bar");
+        assertThat(jedis.exists("foo")).isFalse();
+    }
+
+    //Equivalent of the commented-out expire.tcl test
+    //{GETEX with big integer should report an error}
+    @TestTemplate
+    public void withBigIntegerShouldReportAnError(Jedis jedis) {
+        jedis.set("foo", "bar");
+        assertThatThrownBy(() -> getex(jedis, "foo", "EX", "10000000000000000"))
+                .isInstanceOf(JedisDataException.class)
+                .hasMessage(INVALID_EXPIRE);
+        assertThat(jedis.ttl("foo")).isEqualTo(-1L);
+    }
+
+    //Equivalent of the commented-out expire.tcl test
+    //{GETEX with smallest integer should report an error}
+    @TestTemplate
+    public void withSmallestIntegerShouldReportAnError(Jedis jedis) {
+        jedis.set("foo", "bar");
+        assertThatThrownBy(() -> getex(jedis, "foo", "EX", "-9999999999999999"))
+                .isInstanceOf(JedisDataException.class)
+                .hasMessage(INVALID_EXPIRE);
+        assertThat(jedis.ttl("foo")).isEqualTo(-1L);
+    }
+
+    @TestTemplate
+    public void aNonPositiveExpirationIsRejected(Jedis jedis) {
+        jedis.set("foo", "bar", SetParams.setParams().ex(100));
+        //Zero is out of range for every unit, absolute ones included
+        for (String[] args : new String[][]{
+                {"foo", "EX", "0"}, {"foo", "PX", "0"},
+                {"foo", "EXAT", "0"}, {"foo", "PXAT", "0"},
+                {"foo", "EX", "-1"}, {"foo", "PX", "-1"},
+                {"foo", "EXAT", "-1"}, {"foo", "PXAT", "-1"}}) {
+            assertThatThrownBy(() -> getex(jedis, args))
+                    .as("GETEX %s %s %s", args[0], args[1], args[2])
+                    .isInstanceOf(JedisDataException.class)
+                    .hasMessage(INVALID_EXPIRE);
+        }
+        assertThat(jedis.ttl("foo")).isBetween(90L, 100L);
+    }
+
+    @TestTemplate
+    public void secondsAreRejectedOnceTheyOverflowMilliseconds(Jedis jedis) {
+        jedis.set("foo", "bar");
+        //Both EX and EXAT are multiplied by 1000, so both overflow at LLONG_MAX/1000
+        assertThatThrownBy(() -> getex(jedis, "foo", "EXAT", "9999999999999999"))
+                .isInstanceOf(JedisDataException.class)
+                .hasMessage(INVALID_EXPIRE);
+        assertThatThrownBy(() -> getex(jedis, "foo", "EX", "9223372036854776"))
+                .isInstanceOf(JedisDataException.class)
+                .hasMessage(INVALID_EXPIRE);
+        //A relative expiration is added to the current time, an absolute one is not
+        assertThatThrownBy(() -> getex(jedis, "foo", "PX", String.valueOf(Long.MAX_VALUE)))
+                .isInstanceOf(JedisDataException.class)
+                .hasMessage(INVALID_EXPIRE);
+        assertThat(getexString(jedis, "foo", "PXAT", String.valueOf(Long.MAX_VALUE))).isEqualTo("bar");
+        assertThat(jedis.pexpireTime("foo")).isEqualTo(Long.MAX_VALUE);
+    }
+
+    @TestTemplate
+    public void aNonNumericExpirationIsRejected(Jedis jedis) {
+        jedis.set("foo", "bar");
+        assertThatThrownBy(() -> getex(jedis, "foo", "EX", "abc"))
+                .isInstanceOf(JedisDataException.class)
+                .hasMessage(NOT_AN_INTEGER);
+        assertThatThrownBy(() -> getex(jedis, "foo", "PXAT", "1.5"))
+                .isInstanceOf(JedisDataException.class)
+                .hasMessage(NOT_AN_INTEGER);
+        assertThat(jedis.ttl("foo")).isEqualTo(-1L);
+    }
+
+    @TestTemplate
+    public void unknownIncompleteAndConflictingOptionsAreSyntaxErrors(Jedis jedis) {
+        jedis.set("foo", "bar");
+        for (String[] args : new String[][]{
+                {"foo", "BADOPT"},
+                {"foo", "XX"},
+                {"foo", "KEEPTTL"},
+                {"foo", "EX"},
+                {"foo", "EX", "100", "100"},
+                {"foo", "EX", "100", "PX", "100"},
+                {"foo", "EX", "100", "PERSIST"},
+                {"foo", "PERSIST", "EX", "100"},
+                {"foo", "EXAT", "1", "PXAT", "1"}}) {
+            assertThatThrownBy(() -> getex(jedis, args))
+                    .as("GETEX %s", String.join(" ", args))
+                    .isInstanceOf(JedisDataException.class)
+                    .hasMessage(SYNTAX_ERROR);
+        }
+        assertThat(jedis.ttl("foo")).isEqualTo(-1L);
+    }
+
+    @TestTemplate
+    public void aRepeatedOptionKeepsTheLastValue(Jedis jedis) {
+        jedis.set("foo", "bar");
+        //Only *different* options conflict; the same one twice is accepted
+        assertThat(getexString(jedis, "foo", "EX", "100", "EX", "300")).isEqualTo("bar");
+        assertThat(jedis.ttl("foo")).isBetween(290L, 300L);
+        getex(jedis, "foo", "PERSIST", "PERSIST");
+        assertThat(jedis.ttl("foo")).isEqualTo(-1L);
+    }
+
+    @TestTemplate
+    public void optionsAreCaseInsensitive(Jedis jedis) {
+        jedis.set("foo", "bar");
+        getex(jedis, "foo", "ex", "100");
+        assertThat(jedis.ttl("foo")).isBetween(90L, 100L);
+        getex(jedis, "foo", "PeRsIsT");
+        assertThat(jedis.ttl("foo")).isEqualTo(-1L);
+    }
+
+    @TestTemplate
+    public void withoutAKeyItIsAnArityError(Jedis jedis) {
+        assertThatThrownBy(() -> getex(jedis))
+                .isInstanceOf(JedisDataException.class)
+                .hasMessage("ERR wrong number of arguments for 'getex' command");
+    }
+
+    @TestTemplate
+    public void aKeyOfTheWrongTypeIsReported(Jedis jedis) {
+        jedis.hset("h", "f", "v");
+        assertThatThrownBy(() -> jedis.getEx("h", GetExParams.getExParams()))
+                .isInstanceOf(JedisDataException.class)
+                .hasMessageStartingWith("WRONGTYPE");
+        assertThatThrownBy(() -> jedis.getEx("h", GetExParams.getExParams().ex(100)))
+                .isInstanceOf(JedisDataException.class)
+                .hasMessageStartingWith("WRONGTYPE");
+        assertThat(jedis.hget("h", "f")).isEqualTo("v");
+        assertThat(jedis.ttl("h")).isEqualTo(-1L);
+    }
+
+    @TestTemplate
+    public void theOptionIsParsedBeforeTheKeyIsEvenLookedUp(Jedis jedis) {
+        jedis.rpush("l", "a");
+        //A syntax error outranks both a missing key and a wrong type
+        assertThatThrownBy(() -> getex(jedis, "nosuchkey", "BADOPT"))
+                .isInstanceOf(JedisDataException.class)
+                .hasMessage(SYNTAX_ERROR);
+        assertThatThrownBy(() -> getex(jedis, "l", "BADOPT"))
+                .isInstanceOf(JedisDataException.class)
+                .hasMessage(SYNTAX_ERROR);
+    }
+
+    @TestTemplate
+    public void anOutOfRangeExpirationIsOnlyReportedForAnExistingStringKey(Jedis jedis) {
+        jedis.rpush("l", "a");
+        //A missing key wins: nil, not an error
+        assertThat(getex(jedis, "nosuchkey", "EX", "0")).isNull();
+        assertThat(getex(jedis, "nosuchkey", "EX", "abc")).isNull();
+        //A wrong type wins too
+        assertThatThrownBy(() -> getex(jedis, "l", "EX", "0"))
+                .isInstanceOf(JedisDataException.class)
+                .hasMessageStartingWith("WRONGTYPE");
+    }
+
+    @TestTemplate
+    public void expiredKeysAreTreatedAsMissing(Jedis jedis) {
+        jedis.set("foo", "bar", SetParams.setParams().px(1));
+        Awaitility.await().until(() -> jedis.getEx("foo", GetExParams.getExParams().ex(100)) == null);
+        assertThat(jedis.exists("foo")).isFalse();
+    }
+}

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/strings/GetExTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/strings/GetExTest.java
@@ -11,6 +11,8 @@ import redis.clients.jedis.exceptions.JedisDataException;
 import redis.clients.jedis.params.GetExParams;
 import redis.clients.jedis.params.SetParams;
 
+import java.nio.charset.StandardCharsets;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -42,7 +44,9 @@ public class GetExTest {
 
     private static String getexString(Jedis jedis, String... args) {
         Object reply = getex(jedis, args);
-        return reply == null ? null : new String((byte[]) reply);
+        //Jedis encodes the request as UTF-8, so decode the reply the same way
+        //rather than with whatever the platform default happens to be
+        return reply == null ? null : new String((byte[]) reply, StandardCharsets.UTF_8);
     }
 
     @TestTemplate
@@ -298,7 +302,11 @@ public class GetExTest {
     @TestTemplate
     public void expiredKeysAreTreatedAsMissing(Jedis jedis) {
         jedis.set("foo", "bar", SetParams.setParams().px(1));
-        Awaitility.await().until(() -> jedis.getEx("foo", GetExParams.getExParams().ex(100)) == null);
+        //The poll must not carry an option: an expiring one would reinstate the
+        //TTL on any round that still saw the key, and it would never expire
+        Awaitility.await().until(() -> jedis.getEx("foo", GetExParams.getExParams()) == null);
+        //Nor can the expiring form resurrect what has already gone
+        assertThat(jedis.getEx("foo", GetExParams.getExParams().ex(100))).isNull();
         assertThat(jedis.exists("foo")).isFalse();
     }
 }


### PR DESCRIPTION
Adds `GETEX`, the last unimplemented read-with-expiration string command.

## What this adds

`GETEX key [EX seconds | PX milliseconds | EXAT unix-time-seconds | PXAT unix-time-milliseconds | PERSIST]` — a `GET` that may also change the key's expiration, and nothing else. The value itself is never written.

## Failure ordering is observable, and not what you'd guess

The docs say nothing about this, so each step was established by probing `redis:7.4-alpine` and then pinned with a comparison test:

| Step | Checked | Example |
| --- | --- | --- |
| 1 | Option syntax | `GETEX missing BADOPT` → `ERR syntax error` |
| 2 | Key exists | `GETEX missing EX 0` → **nil**, not an error |
| 3 | Key is a string | `GETEX somelist EX 0` → `WRONGTYPE` |
| 4 | Expiration in range | `GETEX str EX 0` → `ERR invalid expire time in 'getex' command` |

The option is parsed before the key is even looked up, so a syntax error is reported for a missing key and for a key of the wrong type alike. The expiration value, in contrast, is validated *last* — after the key has been found to exist and to hold a string. `GETEX missing EX 0` replying nil rather than erroring is the observable consequence, and it is easy to get backwards.

## Other behaviours verified against real Redis

* **No option leaves the TTL alone.** `GETEX` is not a `PERSIST` in disguise.
* **`EXAT`/`PXAT` in the past return the value *and* delete the key** — the reply is emitted before the deletion.
* **`value <= 0` is rejected for absolute units too.** `EXAT 0` and `PXAT -1` are `ERR invalid expire time`, not deadlines in the past.
* **Seconds overflow at `LLONG_MAX/1000`**, whether relative or absolute: `EXAT 9999999999999999` errors, while `PXAT 9223372036854775807` succeeds — a relative expiration is added to the current time, an absolute one is not.
* **Repeating the *same* option is legal, last one wins.** `GETEX k EX 100 EX 300` sets a 300s TTL; only *different* options conflict. This mirrors Redis's own argument parser, which guards each option against the *others* but not against itself.
* Options are case-insensitive; `KEEPTTL`, `NX` and `XX` are `SET`-only and are syntax errors here.

## Keyspace notifications

All three events belong to the generic (`g`) class — `GETEX` never publishes the string `set`, despite being a write command:

| Invocation | Event |
| --- | --- |
| `EX` / `PX` / `EXAT` / `PXAT` | `expire` |
| `PERSIST` on a key with a TTL | `persist` |
| `PERSIST` on a key without one | *(silent)* |
| `EXAT`/`PXAT` in the past | `del` |
| no option, or a missing key | *(silent)* |

Verified by enabling `Eg`, `E$` and `Ex` in turn against the real server: under `E$` alone none of `GETEX`'s events get through.

## Testing

* **25 comparison tests** in `GetExTest`, each run against both Jedis-Mock and real Redis (50 executions), covering the documentation example, all five options, the four-step failure ordering above, and the overflow boundaries.
* **3 comparison tests** added to `GenericKeyspaceNotificationsTest`, replacing the "GETEX is not implemented by the mock at all" placeholder.
* Every one of those 28 cases was confirmed **red against Jedis-Mock and green against real Redis** before the implementation landed, by temporarily removing `GetEx.java` and re-running.
* **3 upstream tests in `unit/expire.tcl` re-enabled** and passing: `GETEX with big integer should report an error`, `GETEX with smallest integer should report an error`, and `GETEX use of PERSIST option should remove TTL`.
* Full Java suite green: 1862 tests, 0 failures.

## Still out of scope

Three upstream `expire.tcl` tests stay commented out, for reasons unchanged by this PR: the two `GETEX … after loadaof` variants need `DEBUG LOADAOF`, and `GETEX propagate as to replica as PERSIST, DEL, or nothing` needs a replication stream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
