### PR TITLE
getrange/substr and SET ... GET support, plus two SET option bugs

### DIFF
--- a/native_tests/linux/tests/unit/type/string.tcl
+++ b/native_tests/linux/tests/unit/type/string.tcl
@@ -102,6 +102,75 @@ start_server {tags {"string"}} {
         assert_equal 20 [r get x]
     }
 
+    test "GETEX EX option" {
+        r del foo
+        r set foo bar
+        r getex foo ex 10
+        assert_range [r ttl foo] 5 10
+    }
+
+    test "GETEX PX option" {
+        r del foo
+        r set foo bar
+        r getex foo px 10000
+        assert_range [r pttl foo] 5000 10000
+    }
+
+    test "GETEX EXAT option" {
+        r del foo
+        r set foo bar
+        r getex foo exat [expr [clock seconds] + 10]
+        assert_range [r ttl foo] 5 10
+    }
+
+    test "GETEX PXAT option" {
+        r del foo
+        r set foo bar
+        r getex foo pxat [expr [clock milliseconds] + 10000]
+        assert_range [r pttl foo] 5000 10000
+    }
+
+    test "GETEX PERSIST option" {
+        r del foo
+        r set foo bar ex 10
+        assert_range [r ttl foo] 5 10
+        r getex foo persist
+        assert_equal -1 [r ttl foo]
+    }
+
+    test "GETEX no option" {
+        r del foo
+        r set foo bar
+        r getex foo
+        assert_equal bar [r getex foo]
+    }
+
+    test "GETEX syntax errors" {
+        set ex {}
+        catch {r getex foo non-existent-option} ex
+        set ex
+    } {*syntax*}
+
+    test "GETEX and GET expired key or not exist" {
+        r del foo
+        r set foo bar px 1
+        after 2
+        assert_equal {} [r getex foo]
+        assert_equal {} [r get foo]
+    }
+
+    test "GETEX no arguments" {
+         set ex {}
+         catch {r getex} ex
+         set ex
+     } {*wrong number of arguments for 'getex' command}
+
+    test "GETDEL command" {
+        r del foo
+        r set foo bar
+        assert_equal bar [r getdel foo ]
+        assert_equal {} [r getdel foo ]
+    }
     test {MGET} {
         r flushdb
         r set foo BAR
@@ -342,6 +411,11 @@ start_server {tags {"string"}} {
         assert_equal "" [r getrange mykey 0 -1]
     }
 
+    test "GETRANGE against wrong key type" {
+        r lpush lkey1 "list"
+        assert_error {WRONGTYPE Operation against a key holding the wrong kind of value*} {r getrange lkey1 0 -1}
+    }
+
     test "GETRANGE against string value" {
         r set mykey "Hello World"
         assert_equal "Hell" [r getrange mykey 0 3]
@@ -373,6 +447,15 @@ start_server {tags {"string"}} {
         }
     }
 
+    test "Coverage: SUBSTR" {
+        r set key abcde
+        assert_equal "a" [r substr key 0 0]
+        assert_equal "abcd" [r substr key 0 3]
+        assert_equal "bcde" [r substr key -4 -1]
+        assert_equal "" [r substr key -1 -3]
+        assert_equal "" [r substr key 7 8]
+        assert_equal "" [r substr nokey 0 1]
+    }
     test {Extended SET can detect syntax errors} {
         set e {}
         catch {r set foo bar non-existing-option} e
@@ -394,6 +477,58 @@ start_server {tags {"string"}} {
         list $v1 $v2 [r get foo]
     } {{} OK 2}
 
+    test {Extended SET GET option} {
+        r del foo
+        r set foo bar
+        set old_value [r set foo bar2 GET]
+        set new_value [r get foo]
+        list $old_value $new_value
+    } {bar bar2}
+
+    test {Extended SET GET option with no previous value} {
+        r del foo
+        set old_value [r set foo bar GET]
+        set new_value [r get foo]
+        list $old_value $new_value
+    } {{} bar}
+
+    test {Extended SET GET option with XX} {
+        r del foo
+        r set foo bar
+        set old_value [r set foo baz GET XX]
+        set new_value [r get foo]
+        list $old_value $new_value
+    } {bar baz}
+
+    test {Extended SET GET option with XX and no previous value} {
+        r del foo
+        set old_value [r set foo bar GET XX]
+        set new_value [r get foo]
+        list $old_value $new_value
+    } {{} {}}
+
+    test {Extended SET GET option with NX} {
+        r del foo
+        set old_value [r set foo bar GET NX]
+        set new_value [r get foo]
+        list $old_value $new_value
+    } {{} bar}
+
+    test {Extended SET GET option with NX and previous value} {
+        r del foo
+        r set foo bar
+        set old_value [r set foo baz GET NX]
+        set new_value [r get foo]
+        list $old_value $new_value
+    } {bar bar}
+
+    test {Extended SET GET with incorrect type should result in wrong type error} {
+      r del foo
+      r rpush foo waffle
+      catch {r set foo bar GET} err1
+      assert_equal "waffle" [r rpop foo]
+      set err1
+    } {*WRONGTYPE*}
     test {Extended SET EX option} {
         r del foo
         r set foo bar ex 10
@@ -407,6 +542,51 @@ start_server {tags {"string"}} {
         set ttl [r ttl foo]
         assert {$ttl <= 10 && $ttl > 5}
     }
+
+    test "Extended SET EXAT option" {
+        r del foo
+        r set foo bar exat [expr [clock seconds] + 10]
+        assert_range [r ttl foo] 5 10
+    }
+
+    test "Extended SET PXAT option" {
+        r del foo
+        r set foo bar pxat [expr [clock milliseconds] + 10000]
+        assert_range [r ttl foo] 5 10
+    }
+
+    test "SET EXAT / PXAT Expiration time is expired" {
+        r debug set-active-expire 0
+        set repl [attach_to_replication_stream]
+
+        # Key exists.
+        r set foo bar
+        r set foo bar exat [expr [clock seconds] - 100]
+        assert_error {ERR no such key} {r debug object foo}
+        r set foo bar
+        r set foo bar pxat [expr [clock milliseconds] - 10000]
+        assert_error {ERR no such key} {r debug object foo}
+
+        # Key does not exist.
+        r del foo
+        r set foo bar exat [expr [clock seconds] - 100]
+        assert_error {ERR no such key} {r debug object foo}
+        r set foo bar pxat [expr [clock milliseconds] - 10000]
+        assert_error {ERR no such key} {r debug object foo}
+
+        r incr foo
+        assert_replication_stream $repl {
+           {select *}
+           {set foo bar}
+           {unlink foo}
+           {set foo bar}
+           {unlink foo}
+           {incr foo}
+        }
+
+        r debug set-active-expire 1
+        close_replication_stream $repl
+    } {} {needs:debug needs:repl}
 
     test {Extended SET using multiple options at once} {
         r set foo val

--- a/native_tests/linux/tests/unit/type/string.tcl
+++ b/native_tests/linux/tests/unit/type/string.tcl
@@ -337,47 +337,47 @@ start_server {tags {"string"}} {
         assert_error "*maximum allowed size*" {r setrange mykey [expr 512*1024*1024-4] world}
     }
 
-    #test "GETRANGE against non-existing key" {
-    #    r del mykey
-    #    assert_equal "" [r getrange mykey 0 -1]
-    #}
+    test "GETRANGE against non-existing key" {
+        r del mykey
+        assert_equal "" [r getrange mykey 0 -1]
+    }
 
-    #test "GETRANGE against string value" {
-    #    r set mykey "Hello World"
-    #    assert_equal "Hell" [r getrange mykey 0 3]
-    #    assert_equal "Hello World" [r getrange mykey 0 -1]
-    #    assert_equal "orld" [r getrange mykey -4 -1]
-    #    assert_equal "" [r getrange mykey 5 3]
-    #    assert_equal " World" [r getrange mykey 5 5000]
-    #    assert_equal "Hello World" [r getrange mykey -5000 10000]
-    #}
+    test "GETRANGE against string value" {
+        r set mykey "Hello World"
+        assert_equal "Hell" [r getrange mykey 0 3]
+        assert_equal "Hello World" [r getrange mykey 0 -1]
+        assert_equal "orld" [r getrange mykey -4 -1]
+        assert_equal "" [r getrange mykey 5 3]
+        assert_equal " World" [r getrange mykey 5 5000]
+        assert_equal "Hello World" [r getrange mykey -5000 10000]
+    }
 
-    #test "GETRANGE against integer-encoded value" {
-    #    r set mykey 1234
-    #    assert_equal "123" [r getrange mykey 0 2]
-    #    assert_equal "1234" [r getrange mykey 0 -1]
-    #    assert_equal "234" [r getrange mykey -3 -1]
-    #    assert_equal "" [r getrange mykey 5 3]
-    #    assert_equal "4" [r getrange mykey 3 5000]
-    #    assert_equal "1234" [r getrange mykey -5000 10000]
-    #}
+    test "GETRANGE against integer-encoded value" {
+        r set mykey 1234
+        assert_equal "123" [r getrange mykey 0 2]
+        assert_equal "1234" [r getrange mykey 0 -1]
+        assert_equal "234" [r getrange mykey -3 -1]
+        assert_equal "" [r getrange mykey 5 3]
+        assert_equal "4" [r getrange mykey 3 5000]
+        assert_equal "1234" [r getrange mykey -5000 10000]
+    }
 
-    #test "GETRANGE fuzzing" {
-    #    for {set i 0} {$i < 1000} {incr i} {
-    #        r set bin [set bin [randstring 0 1024 binary]]
-    #        set _start [set start [randomInt 1500]]
-    #        set _end [set end [randomInt 1500]]
-    #        if {$_start < 0} {set _start "end-[abs($_start)-1]"}
-    #        if {$_end < 0} {set _end "end-[abs($_end)-1]"}
-    #        assert_equal [string range $bin $_start $_end] [r getrange bin $start $end]
-    #    }
-    #}
+    test "GETRANGE fuzzing" {
+        for {set i 0} {$i < 1000} {incr i} {
+            r set bin [set bin [randstring 0 1024 binary]]
+            set _start [set start [randomInt 1500]]
+            set _end [set end [randomInt 1500]]
+            if {$_start < 0} {set _start "end-[abs($_start)-1]"}
+            if {$_end < 0} {set _end "end-[abs($_end)-1]"}
+            assert_equal [string range $bin $_start $_end] [r getrange bin $start $end]
+        }
+    }
 
-    #test {Extended SET can detect syntax errors} {
-    #    set e {}
-    #    catch {r set foo bar non-existing-option} e
-    #    set e
-    #} {*syntax*}
+    test {Extended SET can detect syntax errors} {
+        set e {}
+        catch {r set foo bar non-existing-option} e
+        set e
+    } {*syntax*}
 
     test {Extended SET NX option} {
         r del foo
@@ -415,10 +415,10 @@ start_server {tags {"string"}} {
         assert {$ttl <= 10 && $ttl > 5}
     }
 
-    #test {GETRANGE with huge ranges, Github issue #1844} {
-    #    r set foo bar
-    #    r getrange foo 0 4294967297
-    #} {bar}
+    test {GETRANGE with huge ranges, Github issue #1844} {
+        r set foo bar
+        r getrange foo 0 4294967297
+    } {bar}
 
     set rna1 {CACCTTCCCAGGTAACAAACCAACCAACTTTCGATCTCTTGTAGATCTGTTCTCTAAACGAACTTTAAAATCTGTGTGGCTGTCACTCGGCTGCATGCTTAGTGCACTCACGCAGTATAATTAATAACTAATTACTGTCGTTGACAGGACACGAGTAACTCGTCTATCTTCTGCAGGCTGCTTACGGTTTCGTCCGTGTTGCAGCCGATCATCAGCACATCTAGGTTTCGTCCGGGTGTG}
     set rna2 {ATTAAAGGTTTATACCTTCCCAGGTAACAAACCAACCAACTTTCGATCTCTTGTAGATCTGTTCTCTAAACGAACTTTAAAATCTGTGTGGCTGTCACTCGGCTGCATGCTTAGTGCACTCACGCAGTATAATTAATAACTAATTACTGTCGTTGACAGGACACGAGTAACTCGTCTATCTTCTGCAGGCTGCTTACGGTTTCGTCCGTGTTGCAGCCGATCATCAGCACATCTAGGTTT}

--- a/src/main/java/com/github/fppt/jedismock/datastructures/RMString.java
+++ b/src/main/java/com/github/fppt/jedismock/datastructures/RMString.java
@@ -22,6 +22,15 @@ public class RMString implements RMDataStructure, Serializable {
         return Arrays.copyOf(storedData, storedData.length);
     }
 
+    /**
+     * The bytes in {@code [from, to)} as a fresh array — the caller gets sole
+     * ownership, exactly as with {@link #getStoredData()}, but a window can be
+     * taken without first duplicating the whole value.
+     */
+    public byte[] getStoredDataRange(int from, int to) {
+        return Arrays.copyOfRange(storedData, from, to);
+    }
+
     public String getStoredDataAsString() {
         return new String(storedData, StandardCharsets.UTF_8);
     }

--- a/src/main/java/com/github/fppt/jedismock/operations/strings/AbstractGetRange.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/strings/AbstractGetRange.java
@@ -1,0 +1,69 @@
+package com.github.fppt.jedismock.operations.strings;
+
+import com.github.fppt.jedismock.datastructures.RMString;
+import com.github.fppt.jedismock.datastructures.Slice;
+import com.github.fppt.jedismock.operations.AbstractRedisOperation;
+import com.github.fppt.jedismock.server.Response;
+import com.github.fppt.jedismock.storage.RedisBase;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.github.fppt.jedismock.Utils.convertToLong;
+
+/**
+ * Shared body of {@link GetRange} and {@link Substr}: one command under two
+ * names, exactly as in real Redis. The only thing that distinguishes them is
+ * the name reported in the arity error, which the base class already takes
+ * from each subclass's own annotation.
+ */
+abstract class AbstractGetRange extends AbstractRedisOperation {
+    AbstractGetRange(RedisBase base, List<Slice> params) {
+        super(base, params);
+    }
+
+    @Override
+    protected int minArgs() {
+        return 3;
+    }
+
+    @Override
+    protected int maxArgs() {
+        return 3;
+    }
+
+    @Override
+    protected Slice response() {
+        //Both offsets are parsed before the key is touched, so a malformed one
+        //is reported ahead of WRONGTYPE or a missing key
+        long start = convertToLong(params().get(1).toString());
+        long end = convertToLong(params().get(2).toString());
+
+        RMString value = base().getRMString(params().get(0));
+        if (value == null) {
+            //An empty bulk string, not a nil — unlike GET
+            return Response.bulkString(Slice.empty());
+        }
+        byte[] data = value.getStoredData();
+        long length = data.length;
+
+        //Adding the length to a negative offset cannot overflow: length is
+        //non-negative, so the sum only ever moves towards zero
+        if (start < 0) {
+            start += length;
+        }
+        if (end < 0) {
+            end += length;
+        }
+        //An offset still negative after that collapses to 0 rather than to an
+        //empty range, so GETRANGE key 0 -100 is the first byte and not ""
+        start = Math.max(start, 0);
+        end = Math.min(Math.max(end, 0), length - 1);
+
+        if (length == 0 || start > end) {
+            return Response.bulkString(Slice.empty());
+        }
+        //Both bounds now lie within [0, length), so the casts are safe
+        return Response.bulkString(Slice.create(Arrays.copyOfRange(data, (int) start, (int) end + 1)));
+    }
+}

--- a/src/main/java/com/github/fppt/jedismock/operations/strings/AbstractGetRange.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/strings/AbstractGetRange.java
@@ -6,7 +6,6 @@ import com.github.fppt.jedismock.operations.AbstractRedisOperation;
 import com.github.fppt.jedismock.server.Response;
 import com.github.fppt.jedismock.storage.RedisBase;
 
-import java.util.Arrays;
 import java.util.List;
 
 import static com.github.fppt.jedismock.Utils.convertToLong;
@@ -44,8 +43,7 @@ abstract class AbstractGetRange extends AbstractRedisOperation {
             //An empty bulk string, not a nil — unlike GET
             return Response.bulkString(Slice.empty());
         }
-        byte[] data = value.getStoredData();
-        long length = data.length;
+        long length = value.size();
 
         //Adding the length to a negative offset cannot overflow: length is
         //non-negative, so the sum only ever moves towards zero
@@ -64,6 +62,6 @@ abstract class AbstractGetRange extends AbstractRedisOperation {
             return Response.bulkString(Slice.empty());
         }
         //Both bounds now lie within [0, length), so the casts are safe
-        return Response.bulkString(Slice.create(Arrays.copyOfRange(data, (int) start, (int) end + 1)));
+        return Response.bulkString(Slice.create(value.getStoredDataRange((int) start, (int) end + 1)));
     }
 }

--- a/src/main/java/com/github/fppt/jedismock/operations/strings/ExpirationArgument.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/strings/ExpirationArgument.java
@@ -1,0 +1,48 @@
+package com.github.fppt.jedismock.operations.strings;
+
+/**
+ * The {@code EX | PX | EXAT | PXAT} argument that SET and GETEX both take.
+ * <p>
+ * Real Redis validates it in one place, {@code getExpireMillisecondsOrReply},
+ * and the easy part to get wrong is the last step: only a <em>relative</em>
+ * expiration has the current time added to it, so {@code EXAT} accepts
+ * deadlines that the very same number would overflow as an {@code EX}.
+ */
+final class ExpirationArgument {
+
+    private ExpirationArgument() {
+    }
+
+    /**
+     * The argument in milliseconds — a duration for the relative options, an
+     * absolute deadline for {@code EXAT} and {@code PXAT}.
+     *
+     * @param command the name to quote in an invalid-expire-time reply
+     * @throws IllegalArgumentException carrying the reply Redis would send
+     */
+    static long millis(String value, boolean seconds, boolean absolute, long now, String command) {
+        long parsed;
+        try {
+            parsed = Long.parseLong(value);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("ERR value is not an integer or out of range");
+        }
+        //A non-positive expiration is out of range for every unit, absolute
+        //ones included, and seconds are rejected once they overflow milliseconds
+        if (parsed <= 0 || seconds && parsed > Long.MAX_VALUE / 1000) {
+            throw invalidExpireTime(command);
+        }
+        long millis = seconds ? parsed * 1000 : parsed;
+        //Only a relative expiration is later offset by the current time, so
+        //only it can overflow; an absolute deadline is already the answer
+        if (!absolute && millis >= Long.MAX_VALUE - now) {
+            throw invalidExpireTime(command);
+        }
+        return millis;
+    }
+
+    static IllegalArgumentException invalidExpireTime(String command) {
+        return new IllegalArgumentException(
+                String.format("ERR invalid expire time in '%s' command", command));
+    }
+}

--- a/src/main/java/com/github/fppt/jedismock/operations/strings/GetEx.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/strings/GetEx.java
@@ -114,30 +114,9 @@ class GetEx extends AbstractRedisOperation {
 
     /** The absolute deadline in milliseconds, rejecting values Redis refuses. */
     private long deadline(Option option, Slice time) {
-        long value;
-        try {
-            value = Long.parseLong(time.toString());
-        } catch (NumberFormatException e) {
-            throw new IllegalArgumentException("ERR value is not an integer or out of range");
-        }
-        //A non-positive expiration is out of range for every unit, absolute ones
-        //included, and seconds are rejected once they overflow milliseconds
-        if (value <= 0 || option.seconds && value > Long.MAX_VALUE / 1000) {
-            throw invalidExpireTime();
-        }
-        long millis = option.seconds ? value * 1000 : value;
-        if (option.absolute) {
-            return millis;
-        }
         long now = base().getClock().millis();
-        if (millis >= Long.MAX_VALUE - now) {
-            throw invalidExpireTime();
-        }
-        return millis + now;
-    }
-
-    private IllegalArgumentException invalidExpireTime() {
-        return new IllegalArgumentException(
-                String.format("ERR invalid expire time in '%s' command", self().value()));
+        long millis = ExpirationArgument.millis(
+                time.toString(), option.seconds, option.absolute, now, self().value());
+        return option.absolute ? millis : millis + now;
     }
 }

--- a/src/main/java/com/github/fppt/jedismock/operations/strings/GetRange.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/strings/GetRange.java
@@ -1,0 +1,19 @@
+package com.github.fppt.jedismock.operations.strings;
+
+import com.github.fppt.jedismock.datastructures.Slice;
+import com.github.fppt.jedismock.operations.RedisCommand;
+import com.github.fppt.jedismock.storage.RedisBase;
+
+import java.util.List;
+
+/**
+ * Returns the inclusive substring between two offsets, either of which may be
+ * negative to count back from the end. See {@link Substr} for the older name
+ * of this same command.
+ */
+@RedisCommand("getrange")
+class GetRange extends AbstractGetRange {
+    GetRange(RedisBase base, List<Slice> params) {
+        super(base, params);
+    }
+}

--- a/src/main/java/com/github/fppt/jedismock/operations/strings/Set.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/strings/Set.java
@@ -9,18 +9,26 @@ import com.github.fppt.jedismock.datastructures.Slice;
 import com.github.fppt.jedismock.storage.KeyspaceEvent;
 import com.github.fppt.jedismock.storage.RedisBase;
 
+import java.util.EnumMap;
 import java.util.List;
-import java.util.function.BiConsumer;
-import java.util.stream.Collectors;
 
+/**
+ * {@code SET key value [NX | XX] [GET] [EX seconds | PX milliseconds |
+ * EXAT unix-time-seconds | PXAT unix-time-milliseconds | KEEPTTL]}.
+ * <p>
+ * The option list is read in a single left-to-right pass, and anything
+ * unrecognised, an option contradicting one already seen, or an expiration
+ * with nothing following it is a syntax error. That whole pass completes
+ * before the expiration value is converted, which is observable: {@code SET k
+ * v EX notanumber} reports the bad conversion, but {@code SET k v EX
+ * notanumber badoption} reports the syntax error instead.
+ */
 @RedisCommand("set")
 class Set extends AbstractRedisOperation {
-    private final List<String> additionalParams;
+    private static final String SYNTAX_ERROR = "ERR syntax error";
 
     Set(RedisBase base, List<Slice> params) {
         super(base, params);
-        additionalParams = params()
-                .stream().skip(2).map(Slice::toString).collect(Collectors.toList());
     }
 
     @Override
@@ -28,123 +36,134 @@ class Set extends AbstractRedisOperation {
         return 2;
     }
 
+    /**
+     * Alternatives that exclude one another. Two <em>different</em> options
+     * from one group are a syntax error; repeating the same one is accepted
+     * and the last occurrence wins, just as in Redis's own argument parser.
+     * GET sits in a group of its own precisely because it conflicts with
+     * nothing.
+     */
+    private enum Group {
+        EXISTENCE, RETURN, EXPIRATION
+    }
+
+    private enum Option {
+        NX(Group.EXISTENCE, false, false, false),
+        XX(Group.EXISTENCE, false, false, false),
+        GET(Group.RETURN, false, false, false),
+        KEEPTTL(Group.EXPIRATION, false, false, false),
+        EX(Group.EXPIRATION, true, true, false),
+        PX(Group.EXPIRATION, true, false, false),
+        EXAT(Group.EXPIRATION, true, true, true),
+        PXAT(Group.EXPIRATION, true, false, true);
+
+        private final Group group;
+        private final boolean takesTime;
+        private final boolean seconds;
+        private final boolean absolute;
+
+        Option(Group group, boolean takesTime, boolean seconds, boolean absolute) {
+            this.group = group;
+            this.takesTime = takesTime;
+            this.seconds = seconds;
+            this.absolute = absolute;
+        }
+
+        static Option of(String name) {
+            for (Option option : values()) {
+                if (option.name().equalsIgnoreCase(name)) {
+                    return option;
+                }
+            }
+            return null;
+        }
+    }
+
     protected Slice response() {
         Slice key = params().get(0);
         Slice value = params().get(1);
-        BiConsumer<Slice, RMDataStructure> valueSetter;
-        try {
-            valueSetter = valueSetter();
-        } catch (IllegalArgumentException e) {
-            return Response.error(e.getMessage());
+
+        EnumMap<Group, Option> chosen = new EnumMap<>(Group.class);
+        Slice time = null;
+        for (int i = 2; i < params().size(); i++) {
+            Option option = Option.of(params().get(i).toString());
+            if (option == null) {
+                return Response.error(SYNTAX_ERROR);
+            }
+            Option previous = chosen.put(option.group, option);
+            if (previous != null && previous != option) {
+                return Response.error(SYNTAX_ERROR);
+            }
+            if (option.takesTime) {
+                if (i + 1 >= params().size()) {
+                    return Response.error(SYNTAX_ERROR);
+                }
+                time = params().get(++i);
+            }
         }
-        if (nx()) {
-            Slice old = base().getSlice(key);
-            if (old == null) {
-                valueSetter.accept(key, value.extract());
-                return Response.OK;
-            } else {
-                return Response.NULL;
+
+        Option existence = chosen.get(Group.EXISTENCE);
+        Option expiration = chosen.get(Group.EXPIRATION);
+        //Only now that the list is known to be well formed is the expiration
+        //looked at, and it is checked before the key is even read
+        long millis = 0;
+        //Only the four timed options set a time, so the two are non-null together
+        if (expiration != null && time != null) {
+            try {
+                millis = parseAndValidate(time.toString(), expiration.seconds ? 1000 : 1);
+            } catch (IllegalArgumentException e) {
+                return Response.error(e.getMessage());
             }
-        } else if (xx()) {
-            Slice old = base().getSlice(key);
-            if (old == null) {
-                return Response.NULL;
-            } else {
-                valueSetter.accept(key, value.extract());
-                return Response.OK;
+        }
+
+        //Raises WRONGTYPE for a non-string key
+        boolean exists = existence != null && base().getSlice(key) != null;
+        if (existence == Option.NX && exists || existence == Option.XX && !exists) {
+            return Response.NULL;
+        }
+        store(key, value.extract(), expiration, millis);
+        return Response.OK;
+    }
+
+    private void store(Slice key, RMDataStructure value, Option expiration, long millis) {
+        if (expiration == Option.KEEPTTL) {
+            Long deadline = base().getDeadline(key);
+            base().putValue(key, value);
+            if (deadline != null) {
+                base().setDeadline(key, deadline);
             }
+        } else if (expiration == null) {
+            base().putValue(key, value);
+        } else if (expiration.absolute) {
+            base().putValue(key, value);
+            base().setDeadline(key, millis);
         } else {
-            valueSetter.accept(key, value.extract());
-            return Response.OK;
+            base().putValue(key, value, millis);
         }
-
-    }
-
-    private boolean nx() {
-        return additionalParams.stream().anyMatch("nx"::equalsIgnoreCase);
-    }
-
-    private boolean xx() {
-        return additionalParams.stream().anyMatch("xx"::equalsIgnoreCase);
-    }
-
-    private boolean keepTTL() {
-        return additionalParams.stream().anyMatch("keepttl"::equalsIgnoreCase);
+        //Reports the assignment, then — when the command also set an
+        //expiration — the generic 'expire', in that order, as real Redis does
+        base().notifyKeyspaceEvent(KeyspaceEvent.SET, key);
+        if (expiration != null && expiration != Option.KEEPTTL) {
+            base().notifyKeyspaceEvent(KeyspaceEvent.EXPIRE, key);
+        }
     }
 
     private long parseAndValidate(String param, int multiplier) {
         long value = Utils.convertToLong(param);
         if (value <= 0) {
-            throw new IllegalArgumentException(String.format(
-                    "ERR invalid expire time in '%s' command", self().value()));
+            throw invalidExpireTime();
         }
         try {
             value = Math.multiplyExact(multiplier, value);
             Math.addExact(base().getClock().millis(), value);
         } catch (ArithmeticException e) {
-            throw new IllegalArgumentException(String.format(
-                    "ERR invalid expire time in '%s' command", self().value()));
+            throw invalidExpireTime();
         }
         return value;
     }
 
-    /**
-     * Reports the assignment, then — when the command also set an expiration —
-     * the generic {@code expire}, in that order, exactly as real Redis does.
-     */
-    private void notifyStored(Slice key, boolean expirationSet) {
-        base().notifyKeyspaceEvent(KeyspaceEvent.SET, key);
-        if (expirationSet) {
-            base().notifyKeyspaceEvent(KeyspaceEvent.EXPIRE, key);
-        }
-    }
-
-    private BiConsumer<Slice, RMDataStructure> valueSetter() {
-        String previous = null;
-        for (String param : additionalParams) {
-            if ("ex".equalsIgnoreCase(previous)) {
-                long ex = parseAndValidate(param, 1000);
-                return (k, v) -> {
-                    base().putValue(k, v, ex);
-                    notifyStored(k, true);
-                };
-            } else if ("px".equalsIgnoreCase(previous)) {
-                long px = parseAndValidate(param, 1);
-                return (k, v) -> {
-                    base().putValue(k, v, px);
-                    notifyStored(k, true);
-                };
-            } else if ("exat".equalsIgnoreCase(previous)) {
-                long exat = parseAndValidate(param, 1000);
-                return (k, v) -> {
-                    base().putValue(k, v);
-                    base().setDeadline(k, exat);
-                    notifyStored(k, true);
-                };
-            } else if ("pxat".equalsIgnoreCase(previous)) {
-                long pxat = parseAndValidate(param, 1);
-                return (k, v) -> {
-                    base().putValue(k, v);
-                    base().setDeadline(k, pxat);
-                    notifyStored(k, true);
-                };
-            }
-            previous = param;
-        }
-        if (keepTTL()) {
-            return (k, v) -> {
-                Long deadline = base().getDeadline(k);
-                base().putValue(k, v);
-                if (deadline != null) {
-                    base().setDeadline(k, deadline);
-                }
-                notifyStored(k, false);
-            };
-        } else {
-            return (k, v) -> {
-                base().putValue(k, v);
-                notifyStored(k, false);
-            };
-        }
+    private IllegalArgumentException invalidExpireTime() {
+        return new IllegalArgumentException(
+                String.format("ERR invalid expire time in '%s' command", self().value()));
     }
 }

--- a/src/main/java/com/github/fppt/jedismock/operations/strings/Set.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/strings/Set.java
@@ -116,10 +116,14 @@ class Set extends AbstractRedisOperation {
             }
         }
 
-        //Raises WRONGTYPE for a non-string key
-        boolean exists = existence != null && base().getSlice(key) != null;
-        if (existence == Option.NX && exists || existence == Option.XX && !exists) {
-            return Response.NULL;
+        //Only the key's presence matters, never its type: SET replaces a value
+        //of any type, so NX on a list declines with a nil and XX overwrites it.
+        //Reading the value instead would wrongly raise WRONGTYPE
+        if (existence != null) {
+            boolean required = existence == Option.XX;
+            if (base().exists(key) != required) {
+                return Response.NULL;
+            }
         }
         store(key, value.extract(), expiration, millis);
         return Response.OK;

--- a/src/main/java/com/github/fppt/jedismock/operations/strings/Set.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/strings/Set.java
@@ -22,6 +22,10 @@ import java.util.List;
  * before the expiration value is converted, which is observable: {@code SET k
  * v EX notanumber} reports the bad conversion, but {@code SET k v EX
  * notanumber badoption} reports the syntax error instead.
+ * <p>
+ * GET replaces the OK with whatever the key held before, or a nil, and reports
+ * it even when NX or XX then declines to write. Reading the old value is also
+ * what makes WRONGTYPE possible: without GET, SET overwrites a key of any type.
  */
 @RedisCommand("set")
 class Set extends AbstractRedisOperation {
@@ -104,6 +108,7 @@ class Set extends AbstractRedisOperation {
 
         Option existence = chosen.get(Group.EXISTENCE);
         Option expiration = chosen.get(Group.EXPIRATION);
+        boolean get = chosen.containsKey(Group.RETURN);
         //Only now that the list is known to be well formed is the expiration
         //looked at, and it is checked before the key is even read
         long millis = 0;
@@ -116,17 +121,24 @@ class Set extends AbstractRedisOperation {
             }
         }
 
-        //Only the key's presence matters, never its type: SET replaces a value
-        //of any type, so NX on a list declines with a nil and XX overwrites it.
-        //Reading the value instead would wrongly raise WRONGTYPE
+        //GET is the one option that reads the key, and so the only reason SET
+        //ever answers WRONGTYPE. It does so only once the expiration has been
+        //accepted, and before NX or XX gets to decide anything
+        Slice previous = get ? base().getSlice(key) : null;
+
+        //For the decision itself only the key's presence matters, never its
+        //type: a plain SET replaces a value of any type, so NX on a list
+        //declines with a nil and XX overwrites it
         if (existence != null) {
             boolean required = existence == Option.XX;
             if (base().exists(key) != required) {
-                return Response.NULL;
+                //A declined write still reports the previous value under GET;
+                //without it, and for an absent key, the reply is a nil
+                return get ? Response.bulkString(previous) : Response.NULL;
             }
         }
         store(key, value.extract(), expiration, millis);
-        return Response.OK;
+        return get ? Response.bulkString(previous) : Response.OK;
     }
 
     private void store(Slice key, RMDataStructure value, Option expiration, long millis) {

--- a/src/main/java/com/github/fppt/jedismock/operations/strings/Set.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/strings/Set.java
@@ -1,6 +1,5 @@
 package com.github.fppt.jedismock.operations.strings;
 
-import com.github.fppt.jedismock.Utils;
 import com.github.fppt.jedismock.datastructures.RMDataStructure;
 import com.github.fppt.jedismock.operations.AbstractRedisOperation;
 import com.github.fppt.jedismock.operations.RedisCommand;
@@ -115,7 +114,8 @@ class Set extends AbstractRedisOperation {
         //Only the four timed options set a time, so the two are non-null together
         if (expiration != null && time != null) {
             try {
-                millis = parseAndValidate(time.toString(), expiration.seconds ? 1000 : 1);
+                millis = ExpirationArgument.millis(time.toString(), expiration.seconds,
+                        expiration.absolute, base().getClock().millis(), self().value());
             } catch (IllegalArgumentException e) {
                 return Response.error(e.getMessage());
             }
@@ -164,22 +164,4 @@ class Set extends AbstractRedisOperation {
         }
     }
 
-    private long parseAndValidate(String param, int multiplier) {
-        long value = Utils.convertToLong(param);
-        if (value <= 0) {
-            throw invalidExpireTime();
-        }
-        try {
-            value = Math.multiplyExact(multiplier, value);
-            Math.addExact(base().getClock().millis(), value);
-        } catch (ArithmeticException e) {
-            throw invalidExpireTime();
-        }
-        return value;
-    }
-
-    private IllegalArgumentException invalidExpireTime() {
-        return new IllegalArgumentException(
-                String.format("ERR invalid expire time in '%s' command", self().value()));
-    }
 }

--- a/src/main/java/com/github/fppt/jedismock/operations/strings/Substr.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/strings/Substr.java
@@ -1,0 +1,18 @@
+package com.github.fppt.jedismock.operations.strings;
+
+import com.github.fppt.jedismock.datastructures.Slice;
+import com.github.fppt.jedismock.operations.RedisCommand;
+import com.github.fppt.jedismock.storage.RedisBase;
+
+import java.util.List;
+
+/**
+ * The original (Redis 1.0) name of {@link GetRange}, deprecated since 2.0 but
+ * still dispatched to the very same implementation.
+ */
+@RedisCommand("substr")
+class Substr extends AbstractGetRange {
+    Substr(RedisBase base, List<Slice> params) {
+        super(base, params);
+    }
+}

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/notifications/StringKeyspaceNotificationsTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/notifications/StringKeyspaceNotificationsTest.java
@@ -114,6 +114,8 @@ public class StringKeyspaceNotificationsTest {
             jedis.msetnx("exists", "other", "fresh", "v");
             jedis.set("missing", "v", SetParams.setParams().xx());
             jedis.set("exists", "v", SetParams.setParams().nx());
+            //GET reports the previous value but does not make the write happen
+            jedis.setGet("exists", "other", SetParams.setParams().nx());
             events.assertNoFurtherNotifications();
         }
     }

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/strings/TestGetRange.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/strings/TestGetRange.java
@@ -1,0 +1,272 @@
+package com.github.fppt.jedismock.comparisontests.strings;
+
+import com.github.fppt.jedismock.comparisontests.ComparisonBase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.Protocol;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * GETRANGE and SUBSTR are two names for one command: SUBSTR is the original
+ * (Redis 1.0), deprecated in 2.0 and renamed GETRANGE in 2.4. The server
+ * dispatches both to the same implementation, so every assertion here is made
+ * against both names — the only observable difference is which name appears in
+ * the arity error.
+ * <p>
+ * Both offsets are inclusive and may be negative (counting back from the end).
+ * They are parsed before the key is looked up, so a malformed offset is
+ * reported ahead of WRONGTYPE or a missing key. Clamping is the subtle part:
+ * an end that is still negative after adding the length collapses to 0 rather
+ * than to "empty", so {@code GETRANGE key 0 -100} returns the first character.
+ */
+@ExtendWith(ComparisonBase.class)
+public class TestGetRange {
+
+    private static final String NOT_AN_INTEGER = "ERR value is not an integer or out of range";
+    private static final String WRONG_TYPE = "WRONGTYPE Operation against a key holding the wrong kind of value";
+
+    private static final Protocol.Command[] BOTH_NAMES = {
+            Protocol.Command.GETRANGE, Protocol.Command.SUBSTR
+    };
+
+    @BeforeEach
+    public void setUp(Jedis jedis) {
+        jedis.flushAll();
+    }
+
+    private static String range(Jedis jedis, Protocol.Command command, String key, String start, String end) {
+        Object reply = jedis.sendCommand(command, key, start, end);
+        //Jedis encodes the request as UTF-8, so decode the reply the same way
+        //rather than with whatever the platform default happens to be
+        return reply == null ? null : new String((byte[]) reply, StandardCharsets.UTF_8);
+    }
+
+    /** Asserts the reply under both names, since they must not diverge. */
+    private static void assertRange(Jedis jedis, String key, String start, String end, String expected) {
+        for (Protocol.Command command : BOTH_NAMES) {
+            assertThat(range(jedis, command, key, start, end))
+                    .describedAs("%s %s %s %s", command, key, start, end)
+                    .isEqualTo(expected);
+        }
+    }
+
+    private static void assertRangeFails(Jedis jedis, String message, String... args) {
+        for (Protocol.Command command : BOTH_NAMES) {
+            assertThatThrownBy(() -> jedis.sendCommand(command, args))
+                    .describedAs("%s %s", command, String.join(" ", args))
+                    .hasMessage(message);
+        }
+    }
+
+    @TestTemplate
+    public void documentationExample(Jedis jedis) {
+        jedis.set("mykey", "This is a string");
+        assertRange(jedis, "mykey", "0", "3", "This");
+        assertRange(jedis, "mykey", "-3", "-1", "ing");
+        assertRange(jedis, "mykey", "0", "-1", "This is a string");
+        assertRange(jedis, "mykey", "10", "100", "string");
+    }
+
+    @TestTemplate
+    public void typedApiAgreesOnBothNames(Jedis jedis) {
+        jedis.set("mykey", "This is a string");
+        assertThat(jedis.getrange("mykey", 0, 3)).isEqualTo("This");
+        assertThat(jedis.substr("mykey", 0, 3)).isEqualTo("This");
+        assertThat(jedis.getrange("mykey", -3, -1)).isEqualTo("ing");
+        assertThat(jedis.substr("mykey", -3, -1)).isEqualTo("ing");
+    }
+
+    @TestTemplate
+    public void againstNonExistingKeyReturnsEmptyString(Jedis jedis) {
+        assertRange(jedis, "nosuchkey", "0", "-1", "");
+        assertRange(jedis, "nosuchkey", "0", "100", "");
+        //An empty bulk string, not a nil — unlike GET
+        assertThat(jedis.getrange("nosuchkey", 0, -1)).isEqualTo("");
+        assertThat(jedis.substr("nosuchkey", 0, -1)).isEqualTo("");
+    }
+
+    @TestTemplate
+    public void againstStringValue(Jedis jedis) {
+        jedis.set("mykey", "Hello World");
+        assertRange(jedis, "mykey", "0", "3", "Hell");
+        assertRange(jedis, "mykey", "0", "-1", "Hello World");
+        assertRange(jedis, "mykey", "-4", "-1", "orld");
+        assertRange(jedis, "mykey", "5", "3", "");
+        assertRange(jedis, "mykey", "5", "5000", " World");
+        assertRange(jedis, "mykey", "-5000", "10000", "Hello World");
+    }
+
+    @TestTemplate
+    public void againstIntegerEncodedValue(Jedis jedis) {
+        jedis.set("mykey", "1234");
+        assertRange(jedis, "mykey", "0", "2", "123");
+        assertRange(jedis, "mykey", "0", "-1", "1234");
+        assertRange(jedis, "mykey", "-3", "-1", "234");
+        assertRange(jedis, "mykey", "5", "3", "");
+        assertRange(jedis, "mykey", "3", "5000", "4");
+        assertRange(jedis, "mykey", "-5000", "10000", "1234");
+    }
+
+    @TestTemplate
+    public void numericValuesAreSlicedAsTheirDecimalText(Jedis jedis) {
+        //Redis stores small integers in an 'int' encoding rather than as bytes,
+        //but GETRANGE materialises the decimal text first, so offsets count
+        //characters — a leading minus sign included
+        jedis.set("negative", "-1234");
+        assertRange(jedis, "negative", "0", "0", "-");
+        assertRange(jedis, "negative", "0", "2", "-12");
+        assertRange(jedis, "negative", "-2", "-1", "34");
+
+        //No normalisation of any kind: the text is sliced exactly as written
+        jedis.set("padded", "007");
+        assertRange(jedis, "padded", "0", "0", "0");
+        assertRange(jedis, "padded", "0", "-1", "007");
+        jedis.set("float", "3.14");
+        assertRange(jedis, "float", "0", "2", "3.1");
+        jedis.set("exponent", "1e3");
+        assertRange(jedis, "exponent", "0", "-1", "1e3");
+
+        jedis.set("big", "9223372036854775807");
+        assertRange(jedis, "big", "0", "2", "922");
+        assertRange(jedis, "big", "-2", "-1", "07");
+    }
+
+    @TestTemplate
+    public void againstValueCreatedNumerically(Jedis jedis) {
+        //A key that was never written as a string still slices as its text
+        jedis.incrBy("counter", 42);
+        assertRange(jedis, "counter", "0", "-1", "42");
+        assertRange(jedis, "counter", "0", "0", "4");
+        assertRange(jedis, "counter", "-1", "-1", "2");
+    }
+
+    @TestTemplate
+    public void againstEmptyStringValue(Jedis jedis) {
+        jedis.set("mykey", "");
+        assertRange(jedis, "mykey", "0", "-1", "");
+        assertRange(jedis, "mykey", "0", "0", "");
+        assertRange(jedis, "mykey", "-1", "-1", "");
+    }
+
+    @TestTemplate
+    public void singleCharacterRanges(Jedis jedis) {
+        jedis.set("mykey", "This is a string");
+        assertRange(jedis, "mykey", "0", "0", "T");
+        assertRange(jedis, "mykey", "-1", "-1", "g");
+        assertRange(jedis, "mykey", "15", "15", "g");
+        //One past the last index
+        assertRange(jedis, "mykey", "16", "16", "");
+    }
+
+    @TestTemplate
+    public void startAfterEndIsEmpty(Jedis jedis) {
+        jedis.set("mykey", "This is a string");
+        assertRange(jedis, "mykey", "5", "2", "");
+        assertRange(jedis, "mykey", "-1", "0", "");
+        //-5 resolves to 11, which is past the end at 10
+        assertRange(jedis, "mykey", "-5", "10", "");
+        assertRange(jedis, "mykey", "-5", "-10", "");
+        //-3 resolves to 13, -20 clamps to 0
+        assertRange(jedis, "mykey", "-3", "-20", "");
+    }
+
+    @TestTemplate
+    public void negativeEndClampsToZeroNotToEmpty(Jedis jedis) {
+        jedis.set("mykey", "This is a string");
+        //An end still negative after adding the length becomes 0, so these
+        //return the first character rather than nothing
+        assertRange(jedis, "mykey", "0", "-100", "T");
+        assertRange(jedis, "mykey", "-20", "-18", "T");
+        assertRange(jedis, "mykey", "-20", "-17", "T");
+        assertRange(jedis, "mykey", "-100", "-100", "T");
+    }
+
+    @TestTemplate
+    public void hugeRanges(Jedis jedis) {
+        jedis.set("foo", "bar");
+        //Github issue #1844: an end past 32 bits must not wrap around
+        assertRange(jedis, "foo", "0", "4294967297", "bar");
+        assertRange(jedis, "foo", "-4294967297", "-1", "bar");
+    }
+
+    @TestTemplate
+    public void longBoundaryOffsets(Jedis jedis) {
+        jedis.set("mykey", "This is a string");
+        assertRange(jedis, "mykey", "0", "9223372036854775807", "This is a string");
+        assertRange(jedis, "mykey", "-9223372036854775808", "-1", "This is a string");
+        assertRange(jedis, "mykey", "9223372036854775807", "-1", "");
+    }
+
+    @TestTemplate
+    public void offsetsOutsideLongRangeAreRejected(Jedis jedis) {
+        jedis.set("mykey", "This is a string");
+        assertRangeFails(jedis, NOT_AN_INTEGER, "mykey", "0", "99999999999999999999");
+        assertRangeFails(jedis, NOT_AN_INTEGER, "mykey", "-99999999999999999999", "-1");
+    }
+
+    @TestTemplate
+    public void nonIntegerOffsetsAreRejected(Jedis jedis) {
+        jedis.set("mykey", "This is a string");
+        assertRangeFails(jedis, NOT_AN_INTEGER, "mykey", "a", "3");
+        assertRangeFails(jedis, NOT_AN_INTEGER, "mykey", "0", "b");
+        assertRangeFails(jedis, NOT_AN_INTEGER, "mykey", "1.5", "3");
+        assertRangeFails(jedis, NOT_AN_INTEGER, "mykey", "", "3");
+    }
+
+    @TestTemplate
+    public void againstKeyWithWrongType(Jedis jedis) {
+        jedis.rpush("mylist", "a");
+        assertRangeFails(jedis, WRONG_TYPE, "mylist", "0", "-1");
+    }
+
+    @TestTemplate
+    public void offsetsAreParsedBeforeTheKeyIsLookedUp(Jedis jedis) {
+        jedis.rpush("mylist", "a");
+        //The bad offset wins over both WRONGTYPE and the missing key
+        assertRangeFails(jedis, NOT_AN_INTEGER, "mylist", "a", "b");
+        assertRangeFails(jedis, NOT_AN_INTEGER, "nosuchkey", "a", "b");
+    }
+
+    @TestTemplate
+    public void wrongNumberOfArgumentsNamesTheCommandAsIssued(Jedis jedis) {
+        for (Protocol.Command command : BOTH_NAMES) {
+            String name = command.name().toLowerCase();
+            String message = String.format("ERR wrong number of arguments for '%s' command", name);
+            assertThatThrownBy(() -> jedis.sendCommand(command))
+                    .hasMessage(message);
+            assertThatThrownBy(() -> jedis.sendCommand(command, "mykey"))
+                    .hasMessage(message);
+            assertThatThrownBy(() -> jedis.sendCommand(command, "mykey", "0"))
+                    .hasMessage(message);
+            assertThatThrownBy(() -> jedis.sendCommand(command, "mykey", "0", "1", "2"))
+                    .hasMessage(message);
+        }
+    }
+
+    @TestTemplate
+    public void isBinarySafe(Jedis jedis) {
+        byte[] key = "bin".getBytes(StandardCharsets.UTF_8);
+        byte[] value = {'a', 0, 'b', (byte) 0xff, 'c'};
+        jedis.set(key, value);
+        assertThat(jedis.getrange(key, 0, -1)).isEqualTo(value);
+        assertThat(jedis.substr(key, 0, -1)).isEqualTo(value);
+        assertThat(jedis.getrange(key, 1, 3)).isEqualTo(new byte[]{0, 'b', (byte) 0xff});
+        assertThat(jedis.substr(key, 1, 3)).isEqualTo(new byte[]{0, 'b', (byte) 0xff});
+        assertThat(jedis.getrange(key, -2, -1)).isEqualTo(new byte[]{(byte) 0xff, 'c'});
+    }
+
+    @TestTemplate
+    public void isReadOnly(Jedis jedis) {
+        jedis.setex("mykey", 100, "This is a string");
+        assertRange(jedis, "mykey", "0", "3", "This");
+        //Neither the value nor its expiration is touched
+        assertThat(jedis.get("mykey")).isEqualTo("This is a string");
+        assertThat(jedis.ttl("mykey")).isEqualTo(100L);
+    }
+}

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/strings/TestSet.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/strings/TestSet.java
@@ -11,10 +11,12 @@ import redis.clients.jedis.params.SetParams;
 import java.util.stream.LongStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @ExtendWith(ComparisonBase.class)
 public class TestSet {
 
+    private static final String INVALID_EXPIRE = "ERR invalid expire time in 'set' command";
     private static final String SET_KEY = "my_simple_key";
     private static final String SET_VALUE = "my_simple_value";
     private static final String SET_ANOTHER_VALUE = "another_value";
@@ -118,6 +120,46 @@ public class TestSet {
                         .hasMessage("ERR invalid expire time in 'set' command")
         );
         softly.assertAll();
+    }
+
+    /**
+     * EXAT and PXAT are already absolute, so — unlike EX and PX — the current
+     * time is never added to them. They therefore accept deadlines that the
+     * very same number overflows as a relative expiration.
+     */
+    @TestTemplate
+    public void absoluteExpirationsAreNotOffsetByTheCurrentTime(Jedis jedis) {
+        assertThat(jedis.set("exat", "v", SetParams.setParams().exAt(9223372036854775L)))
+                .isEqualTo("OK");
+        assertThat(jedis.ttl("exat")).isGreaterThan(0L);
+        assertThat(jedis.set("pxat", "v", SetParams.setParams().pxAt(Long.MAX_VALUE)))
+                .isEqualTo("OK");
+        assertThat(jedis.pexpireTime("pxat")).isEqualTo(Long.MAX_VALUE);
+
+        //The same magnitudes overflow once the current time is added to them
+        assertThatThrownBy(() -> jedis.set("k", "v", SetParams.setParams().ex(9223372036854775L)))
+                .hasMessage(INVALID_EXPIRE);
+        assertThatThrownBy(() -> jedis.set("k", "v", SetParams.setParams().px(Long.MAX_VALUE)))
+                .hasMessage(INVALID_EXPIRE);
+    }
+
+    @TestTemplate
+    public void absoluteExpirationsStillRejectWhatRedisRejects(Jedis jedis) {
+        SoftAssertions softly = new SoftAssertions();
+        //Seconds are refused as soon as they overflow milliseconds
+        softly.assertThatThrownBy(() -> jedis.set("k", "v", SetParams.setParams().exAt(9223372036854776L)))
+                .hasMessage(INVALID_EXPIRE);
+        softly.assertThatThrownBy(() -> jedis.set("k", "v", SetParams.setParams().exAt(Long.MAX_VALUE)))
+                .hasMessage(INVALID_EXPIRE);
+        //A non-positive deadline is out of range for the absolute options too
+        for (long bad : new long[]{0L, -1L}) {
+            softly.assertThatThrownBy(() -> jedis.set("k", "v", SetParams.setParams().exAt(bad)))
+                    .hasMessage(INVALID_EXPIRE);
+            softly.assertThatThrownBy(() -> jedis.set("k", "v", SetParams.setParams().pxAt(bad)))
+                    .hasMessage(INVALID_EXPIRE);
+        }
+        softly.assertAll();
+        assertThat(jedis.exists("k")).isFalse();
     }
 
     @TestTemplate

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/strings/TestSet.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/strings/TestSet.java
@@ -137,6 +137,45 @@ public class TestSet {
         assertThat(jedis.get(NON_EXISTENT)).isEqualTo(SET_VALUE);
     }
 
+    /**
+     * NX and XX ask only whether the key is there, never what it holds, so a
+     * key of another type is ordinary input to them rather than a WRONGTYPE.
+     */
+    @TestTemplate
+    public void nxAndXxLookAtPresenceNotType(Jedis jedis) {
+        jedis.rpush("mylist", "a");
+        //Present, so NX declines — and says so with a nil, not an error
+        assertThat(jedis.set("mylist", "v", SetParams.setParams().nx())).isNull();
+        assertThat(jedis.type("mylist")).isEqualTo("list");
+        //Present, so XX writes, replacing the list with a string
+        assertThat(jedis.set("mylist", "v2", SetParams.setParams().xx())).isEqualTo("OK");
+        assertThat(jedis.type("mylist")).isEqualTo("string");
+        assertThat(jedis.get("mylist")).isEqualTo("v2");
+    }
+
+    @TestTemplate
+    public void xxReplacesAnyTypeAndStillSetsTheExpiration(Jedis jedis) {
+        jedis.hset("myhash", "f", "v");
+        assertThat(jedis.set("myhash", "v2", SetParams.setParams().xx().ex(100L))).isEqualTo("OK");
+        assertThat(jedis.get("myhash")).isEqualTo("v2");
+        assertThat(jedis.ttl("myhash")).isEqualTo(100L);
+    }
+
+    @TestTemplate
+    public void plainSetReplacesAnyType(Jedis jedis) {
+        jedis.sadd("myset", "a");
+        assertThat(jedis.set("myset", "v")).isEqualTo("OK");
+        assertThat(jedis.get("myset")).isEqualTo("v");
+    }
+
+    @TestTemplate
+    public void nxOnAKeyWhoseExpirationHasPassedTreatsItAsAbsent(Jedis jedis) throws InterruptedException {
+        jedis.set(SET_KEY, SET_ANOTHER_VALUE, SetParams.setParams().px(50L));
+        Thread.sleep(150);
+        assertThat(jedis.set(SET_KEY, SET_VALUE, SetParams.setParams().nx())).isEqualTo("OK");
+        assertThat(jedis.get(SET_KEY)).isEqualTo(SET_VALUE);
+    }
+
     @TestTemplate
     public void testSetNonUTF8binary(Jedis jedis) {
         byte[] msg = new byte[]{(byte) 0xbe};

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/strings/TestSetGet.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/strings/TestSetGet.java
@@ -1,0 +1,179 @@
+package com.github.fppt.jedismock.comparisontests.strings;
+
+import com.github.fppt.jedismock.comparisontests.ComparisonBase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.Protocol;
+import redis.clients.jedis.params.SetParams;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * {@code SET key value GET}: the assignment replies with the value the key
+ * held beforehand instead of OK, or nil when it held nothing.
+ * <p>
+ * The reply describes the old value even when the write itself is declined, so
+ * {@code SET k v NX GET} on an existing key reports that value and changes
+ * nothing. Because the option has to read the key, it is also the only way
+ * SET can answer WRONGTYPE — and it does so only after the option list and the
+ * expiration have both been found sound, which puts it fifth in the order of
+ * failures: arity, syntax, non-integer expiration, out-of-range expiration,
+ * then WRONGTYPE.
+ */
+@ExtendWith(ComparisonBase.class)
+public class TestSetGet {
+
+    private static final String WRONG_TYPE = "WRONGTYPE Operation against a key holding the wrong kind of value";
+    private static final String SYNTAX_ERROR = "ERR syntax error";
+    private static final String NOT_AN_INTEGER = "ERR value is not an integer or out of range";
+    private static final String INVALID_EXPIRE = "ERR invalid expire time in 'set' command";
+
+    @BeforeEach
+    public void setUp(Jedis jedis) {
+        jedis.flushDB();
+    }
+
+    private static Object set(Jedis jedis, String... args) {
+        return jedis.sendCommand(Protocol.Command.SET, args);
+    }
+
+    private static String setReply(Jedis jedis, String... args) {
+        Object reply = set(jedis, args);
+        //Jedis encodes the request as UTF-8, so decode the reply the same way
+        //rather than with whatever the platform default happens to be
+        return reply == null ? null : new String((byte[]) reply, StandardCharsets.UTF_8);
+    }
+
+    @TestTemplate
+    public void returnsThePreviousValueAndStillWrites(Jedis jedis) {
+        jedis.set("k", "old");
+        assertThat(jedis.setGet("k", "new")).isEqualTo("old");
+        assertThat(jedis.get("k")).isEqualTo("new");
+    }
+
+    @TestTemplate
+    public void returnsNilForAMissingKeyAndStillWrites(Jedis jedis) {
+        assertThat(jedis.setGet("k", "new")).isNull();
+        assertThat(jedis.get("k")).isEqualTo("new");
+    }
+
+    @TestTemplate
+    public void distinguishesAnEmptyPreviousValueFromAMissingKey(Jedis jedis) {
+        jedis.set("empty", "");
+        assertThat(jedis.setGet("empty", "v")).isEqualTo("");
+        assertThat(jedis.setGet("absent", "v")).isNull();
+    }
+
+    @TestTemplate
+    public void nxDeclinesTheWriteButStillReportsThePreviousValue(Jedis jedis) {
+        jedis.set("k", "old");
+        assertThat(jedis.setGet("k", "new", SetParams.setParams().nx())).isEqualTo("old");
+        //Reported, but deliberately not written
+        assertThat(jedis.get("k")).isEqualTo("old");
+
+        assertThat(jedis.setGet("fresh", "new", SetParams.setParams().nx())).isNull();
+        assertThat(jedis.get("fresh")).isEqualTo("new");
+    }
+
+    @TestTemplate
+    public void xxReportsThePreviousValueOrNilWhenThereIsNone(Jedis jedis) {
+        assertThat(jedis.setGet("absent", "new", SetParams.setParams().xx())).isNull();
+        assertThat(jedis.exists("absent")).isFalse();
+
+        jedis.set("k", "old");
+        assertThat(jedis.setGet("k", "new", SetParams.setParams().xx())).isEqualTo("old");
+        assertThat(jedis.get("k")).isEqualTo("new");
+    }
+
+    @TestTemplate
+    public void appliesTheExpirationAsUsual(Jedis jedis) {
+        jedis.set("k", "old");
+        assertThat(jedis.setGet("k", "new", SetParams.setParams().ex(100L))).isEqualTo("old");
+        assertThat(jedis.ttl("k")).isEqualTo(100L);
+    }
+
+    @TestTemplate
+    public void keepTtlKeepsTheExpirationAndItsAbsenceClearsIt(Jedis jedis) {
+        jedis.set("kept", "old", SetParams.setParams().ex(50L));
+        assertThat(jedis.setGet("kept", "new", SetParams.setParams().keepTtl())).isEqualTo("old");
+        assertThat(jedis.ttl("kept")).isBetween(1L, 50L);
+
+        jedis.set("cleared", "old", SetParams.setParams().ex(50L));
+        assertThat(jedis.setGet("cleared", "new")).isEqualTo("old");
+        assertThat(jedis.ttl("cleared")).isEqualTo(-1L);
+    }
+
+    @TestTemplate
+    public void reportsWrongTypeAndWritesNothing(Jedis jedis) {
+        jedis.rpush("mylist", "a");
+        assertThatThrownBy(() -> jedis.setGet("mylist", "v")).hasMessage(WRONG_TYPE);
+        //NX and XX do not get to decide: the read happens first either way
+        assertThatThrownBy(() -> jedis.setGet("mylist", "v", SetParams.setParams().nx()))
+                .hasMessage(WRONG_TYPE);
+        assertThatThrownBy(() -> jedis.setGet("mylist", "v", SetParams.setParams().xx()))
+                .hasMessage(WRONG_TYPE);
+        assertThat(jedis.type("mylist")).isEqualTo("list");
+
+        jedis.hset("myhash", "f", "v");
+        assertThatThrownBy(() -> jedis.setGet("myhash", "v")).hasMessage(WRONG_TYPE);
+        jedis.zadd("myzset", 1, "a");
+        assertThatThrownBy(() -> jedis.setGet("myzset", "v")).hasMessage(WRONG_TYPE);
+    }
+
+    @TestTemplate
+    public void withoutGetTheSameWritesReplaceTheKeyHappily(Jedis jedis) {
+        //GET is the only reason SET ever reports WRONGTYPE
+        jedis.rpush("mylist", "a");
+        assertThat(jedis.set("mylist", "v")).isEqualTo("OK");
+        assertThat(jedis.get("mylist")).isEqualTo("v");
+    }
+
+    @TestTemplate
+    public void expirationFailuresOutrankWrongType(Jedis jedis) {
+        jedis.rpush("mylist", "a");
+        //The expiration is validated before GET reads anything
+        assertThatThrownBy(() -> set(jedis, "mylist", "v", "GET", "EX", "0"))
+                .hasMessage(INVALID_EXPIRE);
+        assertThatThrownBy(() -> set(jedis, "mylist", "v", "GET", "EX", "notanumber"))
+                .hasMessage(NOT_AN_INTEGER);
+        assertThatThrownBy(() -> set(jedis, "mylist", "v", "GET", "badoption"))
+                .hasMessage(SYNTAX_ERROR);
+        //Written the other way round the outcome is the same
+        assertThatThrownBy(() -> set(jedis, "mylist", "v", "EX", "0", "GET"))
+                .hasMessage(INVALID_EXPIRE);
+        //A sound expiration lets the WRONGTYPE through
+        assertThatThrownBy(() -> set(jedis, "mylist", "v", "GET", "EX", "100"))
+                .hasMessage(WRONG_TYPE);
+        assertThat(jedis.type("mylist")).isEqualTo("list");
+    }
+
+    @TestTemplate
+    public void repeatingGetIsAccepted(Jedis jedis) {
+        jedis.set("k", "old");
+        assertThat(setReply(jedis, "k", "new", "GET", "GET")).isEqualTo("old");
+        assertThat(jedis.get("k")).isEqualTo("new");
+    }
+
+    @TestTemplate
+    public void isBinarySafe(Jedis jedis) {
+        byte[] key = "bin".getBytes(StandardCharsets.UTF_8);
+        byte[] old = {'a', 0, 'b', (byte) 0xff};
+        byte[] fresh = {(byte) 0xfe, 1, 'c'};
+        jedis.set(key, old);
+        assertThat(jedis.setGet(key, fresh)).isEqualTo(old);
+        assertThat(jedis.get(key)).isEqualTo(fresh);
+    }
+
+    @TestTemplate
+    public void anExpiredPreviousValueReadsAsAbsent(Jedis jedis) throws InterruptedException {
+        jedis.set("k", "old", SetParams.setParams().px(50L));
+        Thread.sleep(150);
+        assertThat(jedis.setGet("k", "new")).isNull();
+        assertThat(jedis.get("k")).isEqualTo("new");
+    }
+}

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/strings/TestSetOptionParsing.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/strings/TestSetOptionParsing.java
@@ -1,0 +1,193 @@
+package com.github.fppt.jedismock.comparisontests.strings;
+
+import com.github.fppt.jedismock.comparisontests.ComparisonBase;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.Protocol;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * How SET validates its option list, which is a single left-to-right pass:
+ * an unknown token, an option that conflicts with one already seen, or an
+ * expiration option with nothing following it all produce {@code ERR syntax
+ * error}. Repeating the <em>same</em> option is fine and the last one wins.
+ * <p>
+ * The whole list is checked for syntax before the expiration value is looked
+ * at, so a bad option beats a bad expiration however they are ordered — only
+ * once the list parses does the value get converted (ERR value is not an
+ * integer) and then range-checked (ERR invalid expire time).
+ */
+@ExtendWith(ComparisonBase.class)
+public class TestSetOptionParsing {
+
+    private static final String SYNTAX_ERROR = "ERR syntax error";
+    private static final String NOT_AN_INTEGER = "ERR value is not an integer or out of range";
+    private static final String INVALID_EXPIRE = "ERR invalid expire time in 'set' command";
+
+    @BeforeEach
+    public void setUp(Jedis jedis) {
+        jedis.flushDB();
+    }
+
+    private static Object set(Jedis jedis, String... args) {
+        return jedis.sendCommand(Protocol.Command.SET, args);
+    }
+
+    /** The reply decoded as text: "OK", or null when SET declines to write. */
+    private static String setReply(Jedis jedis, String... args) {
+        Object reply = set(jedis, args);
+        //Jedis encodes the request as UTF-8, so decode the reply the same way
+        //rather than with whatever the platform default happens to be
+        return reply == null ? null : new String((byte[]) reply, StandardCharsets.UTF_8);
+    }
+
+    private static void assertSyntaxError(SoftAssertions softly, Jedis jedis, String... args) {
+        softly.assertThatThrownBy(() -> set(jedis, args))
+                .describedAs("SET %s", String.join(" ", (CharSequence[]) args))
+                .hasMessage(SYNTAX_ERROR);
+    }
+
+    @TestTemplate
+    public void unknownOptionIsASyntaxError(Jedis jedis) {
+        //The case from the native suite: "Extended SET can detect syntax errors"
+        assertThatThrownBy(() -> set(jedis, "foo", "bar", "non-existing-option"))
+                .hasMessage(SYNTAX_ERROR);
+        assertThat(jedis.exists("foo")).isFalse();
+    }
+
+    @TestTemplate
+    public void conflictingOptionsAreASyntaxError(Jedis jedis) {
+        SoftAssertions softly = new SoftAssertions();
+        //NX and XX are mutually exclusive, in either order
+        assertSyntaxError(softly, jedis, "foo", "bar", "nx", "xx");
+        assertSyntaxError(softly, jedis, "foo", "bar", "xx", "nx");
+        //So is any pair of different expiration options
+        assertSyntaxError(softly, jedis, "foo", "bar", "ex", "10", "px", "10000");
+        assertSyntaxError(softly, jedis, "foo", "bar", "ex", "10", "exat", "99999999999");
+        assertSyntaxError(softly, jedis, "foo", "bar", "px", "10000", "pxat", "99999999999999");
+        assertSyntaxError(softly, jedis, "foo", "bar", "exat", "99999999999", "pxat", "99999999999999");
+        //KEEPTTL cannot be combined with an expiration, in either order
+        assertSyntaxError(softly, jedis, "foo", "bar", "keepttl", "ex", "10");
+        assertSyntaxError(softly, jedis, "foo", "bar", "ex", "10", "keepttl");
+        assertSyntaxError(softly, jedis, "foo", "bar", "exat", "99999999999", "keepttl");
+        assertSyntaxError(softly, jedis, "foo", "bar", "keepttl", "pxat", "99999999999999");
+        softly.assertAll();
+    }
+
+    @TestTemplate
+    public void repeatingTheSameOptionIsAllowedAndTheLastWins(Jedis jedis) {
+        assertThat(setReply(jedis, "foo", "bar", "ex", "10", "ex", "200")).isEqualTo("OK");
+        assertThat(jedis.ttl("foo")).isEqualTo(200L);
+        assertThat(setReply(jedis, "foo", "bar", "keepttl", "keepttl")).isEqualTo("OK");
+        assertThat(setReply(jedis, "foo", "bar", "xx", "xx")).isEqualTo("OK");
+        //NX on an existing key declines the write rather than erroring
+        assertThat(setReply(jedis, "foo", "bar", "nx", "nx")).isNull();
+    }
+
+    @TestTemplate
+    public void expirationOptionRequiresAnArgument(Jedis jedis) {
+        SoftAssertions softly = new SoftAssertions();
+        assertSyntaxError(softly, jedis, "foo", "bar", "ex");
+        assertSyntaxError(softly, jedis, "foo", "bar", "px");
+        assertSyntaxError(softly, jedis, "foo", "bar", "exat");
+        assertSyntaxError(softly, jedis, "foo", "bar", "pxat");
+        //Even when other options precede it
+        assertSyntaxError(softly, jedis, "foo", "bar", "nx", "ex");
+        softly.assertAll();
+    }
+
+    @TestTemplate
+    public void expirationOptionSwallowsWhateverFollowsIt(Jedis jedis) {
+        //"nx" here is consumed as EX's argument, not treated as an option, so
+        //this fails on the conversion rather than on the syntax
+        assertThatThrownBy(() -> set(jedis, "foo", "bar", "ex", "nx"))
+                .hasMessage(NOT_AN_INTEGER);
+    }
+
+    @TestTemplate
+    public void optionsAreCaseInsensitive(Jedis jedis) {
+        assertThat(setReply(jedis, "foo", "bar", "Ex", "10")).isEqualTo("OK");
+        assertThat(jedis.ttl("foo")).isEqualTo(10L);
+        assertThat(setReply(jedis, "foo", "bar", "KeepTTL")).isEqualTo("OK");
+        assertThat(setReply(jedis, "foo2", "bar", "NX")).isEqualTo("OK");
+        assertThat(setReply(jedis, "foo3", "bar", "pXaT", "99999999999999")).isEqualTo("OK");
+    }
+
+    @TestTemplate
+    public void syntaxErrorIsReportedBeforeTheExpirationIsExamined(Jedis jedis) {
+        SoftAssertions softly = new SoftAssertions();
+        //Each of these has both a bad option and an unusable expiration; the
+        //syntax error wins regardless of which comes first
+        assertSyntaxError(softly, jedis, "foo", "bar", "ex", "0", "badoption");
+        assertSyntaxError(softly, jedis, "foo", "bar", "badoption", "ex", "0");
+        assertSyntaxError(softly, jedis, "foo", "bar", "ex", "notanumber", "badoption");
+        softly.assertAll();
+    }
+
+    @TestTemplate
+    public void nonIntegerExpirationIsReportedBeforeItsRange(Jedis jedis) {
+        SoftAssertions softly = new SoftAssertions();
+        softly.assertThatThrownBy(() -> set(jedis, "foo", "bar", "ex", "notanumber"))
+                .hasMessage(NOT_AN_INTEGER);
+        softly.assertThatThrownBy(() -> set(jedis, "foo", "bar", "px", "1.5"))
+                .hasMessage(NOT_AN_INTEGER);
+        softly.assertThatThrownBy(() -> set(jedis, "foo", "bar", "exat", ""))
+                .hasMessage(NOT_AN_INTEGER);
+        softly.assertAll();
+    }
+
+    @TestTemplate
+    public void nonPositiveExpirationIsRejected(Jedis jedis) {
+        SoftAssertions softly = new SoftAssertions();
+        for (String option : new String[]{"ex", "px", "exat", "pxat"}) {
+            softly.assertThatThrownBy(() -> set(jedis, "foo", "bar", option, "0"))
+                    .describedAs("SET foo bar %s 0", option)
+                    .hasMessage(INVALID_EXPIRE);
+            softly.assertThatThrownBy(() -> set(jedis, "foo", "bar", option, "-1"))
+                    .describedAs("SET foo bar %s -1", option)
+                    .hasMessage(INVALID_EXPIRE);
+        }
+        softly.assertAll();
+    }
+
+    @TestTemplate
+    public void wrongNumberOfArgumentsIsNotASyntaxError(Jedis jedis) {
+        String message = "ERR wrong number of arguments for 'set' command";
+        assertThatThrownBy(() -> set(jedis)).hasMessage(message);
+        assertThatThrownBy(() -> set(jedis, "foo")).hasMessage(message);
+    }
+
+    @TestTemplate
+    public void getIsAValidOption(Jedis jedis) {
+        //GET must keep parsing cleanly. Its reply — the previous value — is a
+        //separate, still-missing feature, so only the absence of a syntax
+        //error is asserted here
+        jedis.set("foo", "old");
+        assertThatCode(() -> set(jedis, "foo", "bar", "get")).doesNotThrowAnyException();
+        assertThatCode(() -> set(jedis, "foo", "bar", "get", "get")).doesNotThrowAnyException();
+        assertThatCode(() -> set(jedis, "foo", "bar", "nx", "get")).doesNotThrowAnyException();
+        assertThatCode(() -> set(jedis, "foo", "bar", "xx", "get", "ex", "10")).doesNotThrowAnyException();
+        assertThat(jedis.get("foo")).isEqualTo("bar");
+    }
+
+    @TestTemplate
+    public void aRejectedCommandWritesNothing(Jedis jedis) {
+        jedis.set("foo", "original");
+        assertThatThrownBy(() -> set(jedis, "foo", "replacement", "badoption"))
+                .hasMessage(SYNTAX_ERROR);
+        assertThatThrownBy(() -> set(jedis, "foo", "replacement", "ex", "0"))
+                .hasMessage(INVALID_EXPIRE);
+        assertThatThrownBy(() -> set(jedis, "foo", "replacement", "ex", "notanumber"))
+                .hasMessage(NOT_AN_INTEGER);
+        assertThat(jedis.get("foo")).isEqualTo("original");
+        assertThat(jedis.ttl("foo")).isEqualTo(-1L);
+    }
+}

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/strings/TestSetOptionParsing.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/strings/TestSetOptionParsing.java
@@ -11,7 +11,6 @@ import redis.clients.jedis.Protocol;
 import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
@@ -166,16 +165,15 @@ public class TestSetOptionParsing {
     }
 
     @TestTemplate
-    public void getIsAValidOption(Jedis jedis) {
-        //GET must keep parsing cleanly. Its reply — the previous value — is a
-        //separate, still-missing feature, so only the absence of a syntax
-        //error is asserted here
+    public void getCombinesWithEveryOtherOption(Jedis jedis) {
         jedis.set("foo", "old");
-        assertThatCode(() -> set(jedis, "foo", "bar", "get")).doesNotThrowAnyException();
-        assertThatCode(() -> set(jedis, "foo", "bar", "get", "get")).doesNotThrowAnyException();
-        assertThatCode(() -> set(jedis, "foo", "bar", "nx", "get")).doesNotThrowAnyException();
-        assertThatCode(() -> set(jedis, "foo", "bar", "xx", "get", "ex", "10")).doesNotThrowAnyException();
-        assertThat(jedis.get("foo")).isEqualTo("bar");
+        assertThat(setReply(jedis, "foo", "a", "get")).isEqualTo("old");
+        assertThat(setReply(jedis, "foo", "b", "get", "get")).isEqualTo("a");
+        //NX declines the write, yet GET still reports what was there
+        assertThat(setReply(jedis, "foo", "c", "nx", "get")).isEqualTo("b");
+        assertThat(setReply(jedis, "foo", "d", "xx", "get", "ex", "10")).isEqualTo("b");
+        assertThat(jedis.get("foo")).isEqualTo("d");
+        assertThat(jedis.ttl("foo")).isEqualTo(10L);
     }
 
     @TestTemplate


### PR DESCRIPTION
Two independent pieces of work; the second was found while enabling native tests for the first.

## 1. GETRANGE and SUBSTR

New commands. They are one command under two names: `SUBSTR` is the original (Redis 1.0), deprecated in 2.0 and renamed `GETRANGE` in 2.4. `COMMAND INFO` shows identical arity, flags and key specs, and the server dispatches both to the same function — the only observable difference is which name appears in the arity error. Shared body lives in `AbstractGetRange`, with `GetRange` and `Substr` supplying just the annotation, so each reports its own name for free.

Semantics pinned against `redis:7.4-alpine` rather than assumed. The non-obvious parts:

- Both offsets are parsed **before** the key is looked up, so a malformed offset outranks `WRONGTYPE` and the missing-key path: `GETRANGE mylist a b` is `ERR value is not an integer or out of range`, not `WRONGTYPE`.
- An `end` that is still negative after adding the length clamps to `0` rather than making the range empty, so `GETRANGE key 0 -100` returns the **first** character. `start` clamps the same way, which is why `-3 -20` is empty but `-20 -18` is `"T"`.
- A missing key replies with an empty bulk string, not a nil like `GET`.
- Offsets are 64-bit; `9223372036854775807` is accepted, `99999999999999999999` is rejected.
- Numeric values are sliced as their decimal text, so the minus sign of `-1234` occupies offset 0, and a key created by `INCRBY` slices the same way.

`TestGetRange` has 20 `@TestTemplate` methods (40 runs). Every assertion is made under **both** names via a shared helper, so the two can never drift apart. The `GETRANGE` blocks in `native_tests/linux/tests/unit/type/string.tcl` that were commented out pending support — including the 1000-iteration fuzzer and the huge-range case from redis#1844 — are now enabled.

## 2. SET: the GET option, and two bugs

Uncommenting *"Extended SET can detect syntax errors"* in the same native suite turned up two defects, and closing the gap they exposed brought `SET ... GET` with them.

### `SET ... GET` is now implemented

The assignment replies with whatever the key held beforehand, or a nil, instead of `OK`. Previously the option parsed but was silently ignored, so the reply was `OK` and the old value was lost.

- A **declined** write still reports the previous value: `SET k new NX GET` on an existing key returns the old value and leaves it in place. `XX GET` on a missing key returns nil and writes nothing.
- Nil and empty string stay distinct — a previous value of `""` comes back as an empty bulk string.
- GET is the only reason SET can answer `WRONGTYPE`; without it, SET overwrites a key of any type. The read happens after the expiration has been accepted but before NX/XX decides, so `SET mylist v NX GET` is `WRONGTYPE` rather than a declined write.

### Unknown and conflicting options were silently ignored

`SET foo bar non-existing-option` stored the value and replied `OK`. The old code just scanned the trailing arguments for tokens it recognised. Now the option list is read in a single pass and rejects an unrecognised token, `NX`+`XX`, any two different expiration options, `KEEPTTL` alongside an expiration, and an expiration option with nothing following it. Repeating the *same* option remains legal with the last one winning, matching Redis — `SET k v EX 10 EX 200` gives a TTL of 200, where the old loop returned 10.

The full order of failures is observable and now matches:

```
SET k v EX notanumber            -> ERR value is not an integer or out of range
SET k v EX notanumber badoption  -> ERR syntax error                  (parse fails first)
SET k v EX 0                     -> ERR invalid expire time in 'set' command
SET k v EX 0 badoption           -> ERR syntax error
SET mylist v GET EX 0            -> ERR invalid expire time           (expiration beats the read)
SET mylist v GET EX 100          -> WRONGTYPE                         (read beats NX/XX)
```

### NX and XX raised WRONGTYPE against a key of another type

They only ask whether the key is present, never what it holds — Redis uses a bare `lookupKeyWrite` with no type check there. `SET mylist v NX` must reply nil and `SET mylist v XX` must replace the list with a string; both returned `WRONGTYPE` instead. Fixed by using `RedisBase.exists`, which keeps the lazy-expiry behaviour without the type coercion.

Parsing was rewritten to the enum-with-fields shape already used by `GetEx`, extended with a `Group` so mutual exclusion is expressed once rather than as hand-maintained guards at each branch. That `EnumMap`-based conflict check is where the first bug lived.

Covered by `TestSetGet` (13 methods), `TestSetOptionParsing` (12 methods), four new methods in `TestSet`, and a declined-`NX GET` case in `StringKeyspaceNotificationsTest` confirming a write that does not happen stays silent.

## Notes

- `supported_operations.md` is left alone; CI regenerates it.
- Full suite green: 1960 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)