### PR TITLE
implement sintercard

### DIFF
--- a/native_tests/linux/tests/unit/type/set.tcl
+++ b/native_tests/linux/tests/unit/type/set.tcl
@@ -232,40 +232,40 @@ foreach type {single multiple single_multiple} {
         r srem myset 1 2 3 4 5 6 7 8
     } {3}
 
-#    test "SINTERCARD with illegal arguments" {
-#        assert_error "ERR wrong number of arguments for 'sintercard' command" {r sintercard}
-#        assert_error "ERR wrong number of arguments for 'sintercard' command" {r sintercard 1}
-#
-#        assert_error "ERR numkeys*" {r sintercard 0 myset{t}}
-#        assert_error "ERR numkeys*" {r sintercard a myset{t}}
-#
-#        assert_error "ERR Number of keys*" {r sintercard 2 myset{t}}
-#        assert_error "ERR Number of keys*" {r sintercard 3 myset{t} myset2{t}}
-#
-#        assert_error "ERR syntax error*" {r sintercard 1 myset{t} myset2{t}}
-#        assert_error "ERR syntax error*" {r sintercard 1 myset{t} bar_arg}
-#        assert_error "ERR syntax error*" {r sintercard 1 myset{t} LIMIT}
-#
-#        assert_error "ERR LIMIT*" {r sintercard 1 myset{t} LIMIT -1}
-#        assert_error "ERR LIMIT*" {r sintercard 1 myset{t} LIMIT a}
-#    }
-#
-#    test "SINTERCARD against non-set should throw error" {
-#        r del set{t}
-#        r sadd set{t} a b c
-#        r set key1{t} x
-#
-#        assert_error "WRONGTYPE*" {r sintercard 1 key1{t}}
-#        assert_error "WRONGTYPE*" {r sintercard 2 set{t} key1{t}}
-#        assert_error "WRONGTYPE*" {r sintercard 2 key1{t} noset{t}}
-#    }
-#
-#    test "SINTERCARD against non-existing key" {
-#        assert_equal 0 [r sintercard 1 non-existing-key]
-#        assert_equal 0 [r sintercard 1 non-existing-key limit 0]
-#        assert_equal 0 [r sintercard 1 non-existing-key limit 10]
-#    }
-#
+    test "SINTERCARD with illegal arguments" {
+        assert_error "ERR wrong number of arguments for 'sintercard' command" {r sintercard}
+        assert_error "ERR wrong number of arguments for 'sintercard' command" {r sintercard 1}
+
+        assert_error "ERR numkeys*" {r sintercard 0 myset{t}}
+        assert_error "ERR numkeys*" {r sintercard a myset{t}}
+
+        assert_error "ERR Number of keys*" {r sintercard 2 myset{t}}
+        assert_error "ERR Number of keys*" {r sintercard 3 myset{t} myset2{t}}
+
+        assert_error "ERR syntax error*" {r sintercard 1 myset{t} myset2{t}}
+        assert_error "ERR syntax error*" {r sintercard 1 myset{t} bar_arg}
+        assert_error "ERR syntax error*" {r sintercard 1 myset{t} LIMIT}
+
+        assert_error "ERR LIMIT*" {r sintercard 1 myset{t} LIMIT -1}
+        assert_error "ERR LIMIT*" {r sintercard 1 myset{t} LIMIT a}
+    }
+
+    test "SINTERCARD against non-set should throw error" {
+        r del set{t}
+        r sadd set{t} a b c
+        r set key1{t} x
+
+        assert_error "WRONGTYPE*" {r sintercard 1 key1{t}}
+        assert_error "WRONGTYPE*" {r sintercard 2 set{t} key1{t}}
+        assert_error "WRONGTYPE*" {r sintercard 2 key1{t} noset{t}}
+    }
+
+    test "SINTERCARD against non-existing key" {
+        assert_equal 0 [r sintercard 1 non-existing-key]
+        assert_equal 0 [r sintercard 1 non-existing-key limit 0]
+        assert_equal 0 [r sintercard 1 non-existing-key limit 10]
+    }
+
     foreach {type} {regular intset} {
         # Create sets setN{t} where N = 1..5
         if {$type eq "regular"} {
@@ -316,12 +316,12 @@ foreach type {single multiple single_multiple} {
             assert_equal [list 195 196 197 198 199 $large] [lsort [r sinter set1{t} set2{t}]]
         }
 
-#        test "SINTERCARD with two sets - $type" {
-#            assert_equal 6 [r sintercard 2 set1{t} set2{t}]
-#            assert_equal 6 [r sintercard 2 set1{t} set2{t} limit 0]
-#            assert_equal 3 [r sintercard 2 set1{t} set2{t} limit 3]
-#            assert_equal 6 [r sintercard 2 set1{t} set2{t} limit 10]
-#        }
+        test "SINTERCARD with two sets - $type" {
+            assert_equal 6 [r sintercard 2 set1{t} set2{t}]
+            assert_equal 6 [r sintercard 2 set1{t} set2{t} limit 0]
+            assert_equal 3 [r sintercard 2 set1{t} set2{t} limit 3]
+            assert_equal 6 [r sintercard 2 set1{t} set2{t} limit 10]
+        }
 
         test "SINTERSTORE with two sets - $type" {
             r sinterstore setres{t} set1{t} set2{t}
@@ -352,12 +352,12 @@ foreach type {single multiple single_multiple} {
             assert_equal [list 195 199 $large] [lsort [r sinter set1{t} set2{t} set3{t}]]
         }
 
-#        test "SINTERCARD against three sets - $type" {
-#            assert_equal 3 [r sintercard 3 set1{t} set2{t} set3{t}]
-#            assert_equal 3 [r sintercard 3 set1{t} set2{t} set3{t} limit 0]
-#            assert_equal 2 [r sintercard 3 set1{t} set2{t} set3{t} limit 2]
-#            assert_equal 3 [r sintercard 3 set1{t} set2{t} set3{t} limit 10]
-#        }
+        test "SINTERCARD against three sets - $type" {
+            assert_equal 3 [r sintercard 3 set1{t} set2{t} set3{t}]
+            assert_equal 3 [r sintercard 3 set1{t} set2{t} set3{t} limit 0]
+            assert_equal 2 [r sintercard 3 set1{t} set2{t} set3{t} limit 2]
+            assert_equal 3 [r sintercard 3 set1{t} set2{t} set3{t} limit 10]
+        }
 
         test "SINTERSTORE with three sets - $type" {
             r sinterstore setres{t} set1{t} set2{t} set3{t}

--- a/src/main/java/com/github/fppt/jedismock/Utils.java
+++ b/src/main/java/com/github/fppt/jedismock/Utils.java
@@ -3,11 +3,21 @@ package com.github.fppt.jedismock;
 import com.github.fppt.jedismock.exception.WrongValueTypeException;
 
 import java.io.Closeable;
+import java.util.OptionalLong;
+import java.util.regex.Pattern;
 
 /**
  * Created by Xiaolu on 2015/4/21.
  */
 public class Utils {
+
+    /**
+     * The integers Redis' own {@code string2ll} accepts: no leading plus, no
+     * leading zeroes, no {@code -0} and no surrounding whitespace. Java's
+     * {@link Long#parseLong} is more permissive than all of these, so the
+     * grammar has to be checked before parsing.
+     */
+    private static final Pattern REDIS_INTEGER = Pattern.compile("0|-?[1-9][0-9]*");
 
     public static void closeQuietly(Closeable closeable) {
         try {
@@ -17,12 +27,26 @@ public class Utils {
         }
     }
 
-    public static long convertToLong(String value) {
-        try {
-            return Long.parseLong(value);
-        } catch (NumberFormatException e) {
-            throw new WrongValueTypeException("ERR value is not an integer or out of range");
+    /**
+     * Parses {@code value} exactly as Redis' {@code string2ll} would, returning
+     * empty rather than throwing so callers can raise the error message their
+     * own command uses.
+     */
+    public static OptionalLong parseRedisLong(String value) {
+        if (!REDIS_INTEGER.matcher(value).matches()) {
+            return OptionalLong.empty();
         }
+        try {
+            return OptionalLong.of(Long.parseLong(value));
+        } catch (NumberFormatException e) {
+            //Grammatically an integer, but out of range
+            return OptionalLong.empty();
+        }
+    }
+
+    public static long convertToLong(String value) {
+        return parseRedisLong(value).orElseThrow(() ->
+                new WrongValueTypeException("ERR value is not an integer or out of range"));
     }
 
     public static byte convertToByte(String value) {
@@ -38,21 +62,21 @@ public class Utils {
     }
 
     public static int convertToNonNegativeInteger(String value) {
-        try {
-            int pos = Integer.parseInt(value);
-            if (pos < 0) throw new NumberFormatException("Int less than 0");
-            return pos;
-        } catch (NumberFormatException e) {
+        OptionalLong parsed = parseRedisLong(value);
+        if (!parsed.isPresent() || parsed.getAsLong() < 0 || parsed.getAsLong() > Integer.MAX_VALUE) {
             throw new WrongValueTypeException("ERR bit offset is not an integer or out of range");
         }
+        return (int) parsed.getAsLong();
     }
 
     public static int convertToInteger(String value) {
-        try {
-            return Integer.parseInt(value);
-        } catch (NumberFormatException e) {
+        OptionalLong parsed = parseRedisLong(value);
+        if (!parsed.isPresent()
+                || parsed.getAsLong() < Integer.MIN_VALUE
+                || parsed.getAsLong() > Integer.MAX_VALUE) {
             throw new WrongValueTypeException("ERR value is not an integer or out of range");
         }
+        return (int) parsed.getAsLong();
     }
 
     public static double convertToDouble(String value) {

--- a/src/main/java/com/github/fppt/jedismock/operations/keys/paramsparser/ExpirationTimeParam.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/keys/paramsparser/ExpirationTimeParam.java
@@ -1,6 +1,9 @@
 package com.github.fppt.jedismock.operations.keys.paramsparser;
 
+import com.github.fppt.jedismock.Utils;
 import com.github.fppt.jedismock.datastructures.Slice;
+
+import java.util.OptionalLong;
 
 public final class ExpirationTimeParam {
     private final long millis;
@@ -9,12 +12,11 @@ public final class ExpirationTimeParam {
                         Slice param,
                         boolean useMillis,
                         long timestampToCheckOverflow) throws ExpirationParamsException {
-        long value;
-        try {
-            value = Long.parseLong(new String(param.data()));
-        } catch (NumberFormatException e) {
+        OptionalLong parsed = Utils.parseRedisLong(new String(param.data()));
+        if (!parsed.isPresent()) {
             throw new ExpirationParamsException("ERR value is not an integer or out of range");
         }
+        long value = parsed.getAsLong();
         try {
             millis = useMillis ? value : Math.multiplyExact(value, 1000L);
             Math.addExact(millis, timestampToCheckOverflow);

--- a/src/main/java/com/github/fppt/jedismock/operations/sets/SInterCard.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/sets/SInterCard.java
@@ -1,0 +1,63 @@
+package com.github.fppt.jedismock.operations.sets;
+
+import com.github.fppt.jedismock.Utils;
+import com.github.fppt.jedismock.datastructures.Slice;
+import com.github.fppt.jedismock.operations.AbstractRedisOperation;
+import com.github.fppt.jedismock.operations.RedisCommand;
+import com.github.fppt.jedismock.server.Response;
+import com.github.fppt.jedismock.storage.RedisBase;
+
+import java.util.List;
+
+@RedisCommand("sintercard")
+class SInterCard extends AbstractRedisOperation {
+    private static final String LIMIT = "LIMIT";
+
+    SInterCard(RedisBase base, List<Slice> params) {
+        super(base, params);
+    }
+
+    @Override
+    protected int minArgs() {
+        return 2;
+    }
+
+    @Override
+    protected Slice response() {
+        long numKeys = parseInteger(params().get(0));
+        if (numKeys < 1) {
+            return Response.error("ERR numkeys should be greater than 0");
+        }
+        if (numKeys > params().size() - 1) {
+            return Response.error("ERR Number of keys can't be greater than number of args");
+        }
+        int keyCount = (int) numKeys;
+
+        //Everything after the keys must be LIMIT <count>, repeated; the last one wins
+        long limit = 0;
+        for (int i = keyCount + 1; i < params().size(); i += 2) {
+            if (!LIMIT.equalsIgnoreCase(params().get(i).toString()) || i + 1 == params().size()) {
+                return Response.error("ERR syntax error");
+            }
+            limit = parseInteger(params().get(i + 1));
+            if (limit < 0) {
+                return Response.error("ERR LIMIT can't be negative");
+            }
+        }
+
+        //Arguments are fully validated before any key is touched, so a syntax
+        //error is reported in preference to the WRONGTYPE a bad key would raise
+        int cardinality = new SInter(base(), params().subList(1, keyCount + 1))
+                .getIntersection().size();
+        return Response.integer(limit == 0 ? cardinality : Math.min(cardinality, limit));
+    }
+
+    /**
+     * Parses {@code param} the way Redis would, mapping anything unparseable to
+     * -1. Both callers reject negatives anyway, so a malformed argument and an
+     * out-of-range one produce the same reply — as they do on a real server.
+     */
+    private static long parseInteger(Slice param) {
+        return Utils.parseRedisLong(param.toString()).orElse(-1);
+    }
+}

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/StrictIntegerParsingTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/StrictIntegerParsingTest.java
@@ -1,0 +1,77 @@
+package com.github.fppt.jedismock.comparisontests;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.Protocol;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Redis parses integer arguments with {@code string2ll}, which is stricter than
+ * Java's {@link Long#parseLong}: a leading plus, leading zeroes, {@code -0} and
+ * surrounding whitespace are all rejected. These are shared by every command
+ * that takes an integer, so they are tested once here rather than per command.
+ */
+@ExtendWith(ComparisonBase.class)
+public class StrictIntegerParsingTest {
+
+    private static final String NOT_AN_INTEGER = "ERR value is not an integer or out of range";
+    private static final String NOT_AN_OFFSET = "ERR bit offset is not an integer or out of range";
+
+    @BeforeEach
+    public void setUp(Jedis jedis) {
+        jedis.flushAll();
+        jedis.set("n", "10");
+        jedis.rpush("mylist", "a", "b", "c");
+    }
+
+    @TestTemplate
+    public void leadingPlusIsRejected(Jedis jedis) {
+        assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.INCRBY, "n", "+1"))
+                .hasMessage(NOT_AN_INTEGER);
+        assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.DECRBY, "n", "+1"))
+                .hasMessage(NOT_AN_INTEGER);
+        assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.EXPIRE, "n", "+100"))
+                .hasMessage(NOT_AN_INTEGER);
+        assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.LRANGE, "mylist", "+0", "-1"))
+                .hasMessage(NOT_AN_INTEGER);
+        assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.SETBIT, "bk", "+1", "1"))
+                .hasMessage(NOT_AN_OFFSET);
+    }
+
+    @TestTemplate
+    public void leadingZeroIsRejected(Jedis jedis) {
+        assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.INCRBY, "n", "01"))
+                .hasMessage(NOT_AN_INTEGER);
+        assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.EXPIRE, "n", "01"))
+                .hasMessage(NOT_AN_INTEGER);
+        assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.LRANGE, "mylist", "00", "-1"))
+                .hasMessage(NOT_AN_INTEGER);
+        assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.GETBIT, "bk", "01"))
+                .hasMessage(NOT_AN_OFFSET);
+    }
+
+    @TestTemplate
+    public void negativeZeroAndWhitespaceAreRejected(Jedis jedis) {
+        assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.INCRBY, "n", "-0"))
+                .hasMessage(NOT_AN_INTEGER);
+        assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.INCRBY, "n", " 1"))
+                .hasMessage(NOT_AN_INTEGER);
+        assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.INCRBY, "n", "1 "))
+                .hasMessage(NOT_AN_INTEGER);
+        assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.INCRBY, "n", ""))
+                .hasMessage(NOT_AN_INTEGER);
+    }
+
+    @TestTemplate
+    public void wellFormedIntegersAreStillAccepted(Jedis jedis) {
+        assertThat(jedis.incrBy("n", -5)).isEqualTo(5);
+        assertThat(jedis.incrBy("n", 0)).isEqualTo(5);
+        assertThat(jedis.getrange("n", 0, -1)).isEqualTo("5");
+        assertThat(jedis.lrange("mylist", 0, -1)).containsExactly("a", "b", "c");
+        assertThat(jedis.setbit("bk", 0, true)).isFalse();
+    }
+}

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/sets/SInterCardTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/sets/SInterCardTest.java
@@ -1,0 +1,231 @@
+package com.github.fppt.jedismock.comparisontests.sets;
+
+import com.github.fppt.jedismock.comparisontests.ComparisonBase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.Protocol;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@ExtendWith(ComparisonBase.class)
+public class SInterCardTest {
+
+    @BeforeEach
+    public void setUp(Jedis jedis) {
+        jedis.flushAll();
+    }
+
+    @TestTemplate
+    public void wrongNumberOfArguments(Jedis jedis) {
+        assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.SINTERCARD))
+                .hasMessage("ERR wrong number of arguments for 'sintercard' command");
+        assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.SINTERCARD, "1"))
+                .hasMessage("ERR wrong number of arguments for 'sintercard' command");
+    }
+
+    @TestTemplate
+    public void illegalNumkeys(Jedis jedis) {
+        jedis.sadd("myset", "a", "b", "c");
+
+        assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.SINTERCARD, "0", "myset"))
+                .hasMessage("ERR numkeys should be greater than 0");
+        assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.SINTERCARD, "-1", "myset"))
+                .hasMessage("ERR numkeys should be greater than 0");
+        assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.SINTERCARD, "a", "myset"))
+                .hasMessage("ERR numkeys should be greater than 0");
+        assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.SINTERCARD, "1.5", "myset"))
+                .hasMessage("ERR numkeys should be greater than 0");
+        //Redis' string2ll rejects a leading plus, leading zeroes and overflow
+        assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.SINTERCARD, "+1", "myset"))
+                .hasMessage("ERR numkeys should be greater than 0");
+        assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.SINTERCARD, "01", "myset"))
+                .hasMessage("ERR numkeys should be greater than 0");
+        assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.SINTERCARD, " 1", "myset"))
+                .hasMessage("ERR numkeys should be greater than 0");
+        assertThatThrownBy(() ->
+                jedis.sendCommand(Protocol.Command.SINTERCARD, "99999999999999999999", "myset"))
+                .hasMessage("ERR numkeys should be greater than 0");
+    }
+
+    @TestTemplate
+    public void numkeysGreaterThanNumberOfArgs(Jedis jedis) {
+        jedis.sadd("myset", "a", "b", "c");
+        jedis.sadd("myset2", "b", "c", "d");
+
+        assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.SINTERCARD, "2", "myset"))
+                .hasMessage("ERR Number of keys can't be greater than number of args");
+        assertThatThrownBy(() ->
+                jedis.sendCommand(Protocol.Command.SINTERCARD, "3", "myset", "myset2"))
+                .hasMessage("ERR Number of keys can't be greater than number of args");
+        //A numkeys too large for an int is still just too large for the argument count
+        assertThatThrownBy(() ->
+                jedis.sendCommand(Protocol.Command.SINTERCARD, "3000000000", "myset"))
+                .hasMessage("ERR Number of keys can't be greater than number of args");
+    }
+
+    @TestTemplate
+    public void syntaxErrors(Jedis jedis) {
+        jedis.sadd("myset", "a", "b", "c");
+        jedis.sadd("myset2", "b", "c", "d");
+
+        assertThatThrownBy(() ->
+                jedis.sendCommand(Protocol.Command.SINTERCARD, "1", "myset", "myset2"))
+                .hasMessage("ERR syntax error");
+        assertThatThrownBy(() ->
+                jedis.sendCommand(Protocol.Command.SINTERCARD, "1", "myset", "bar_arg"))
+                .hasMessage("ERR syntax error");
+        assertThatThrownBy(() ->
+                jedis.sendCommand(Protocol.Command.SINTERCARD, "1", "myset", "LIMIT"))
+                .hasMessage("ERR syntax error");
+        assertThatThrownBy(() ->
+                jedis.sendCommand(Protocol.Command.SINTERCARD, "1", "myset", "LIMIT", "1", "extra"))
+                .hasMessage("ERR syntax error");
+    }
+
+    @TestTemplate
+    public void illegalLimit(Jedis jedis) {
+        jedis.sadd("myset", "a", "b", "c");
+
+        assertThatThrownBy(() ->
+                jedis.sendCommand(Protocol.Command.SINTERCARD, "1", "myset", "LIMIT", "-1"))
+                .hasMessage("ERR LIMIT can't be negative");
+        assertThatThrownBy(() ->
+                jedis.sendCommand(Protocol.Command.SINTERCARD, "1", "myset", "LIMIT", "a"))
+                .hasMessage("ERR LIMIT can't be negative");
+        assertThatThrownBy(() ->
+                jedis.sendCommand(Protocol.Command.SINTERCARD, "1", "myset", "LIMIT", "1.5"))
+                .hasMessage("ERR LIMIT can't be negative");
+        assertThatThrownBy(() ->
+                jedis.sendCommand(Protocol.Command.SINTERCARD, "1", "myset", "LIMIT", ""))
+                .hasMessage("ERR LIMIT can't be negative");
+        assertThatThrownBy(() ->
+                jedis.sendCommand(Protocol.Command.SINTERCARD, "1", "myset", "LIMIT", "+1"))
+                .hasMessage("ERR LIMIT can't be negative");
+        assertThatThrownBy(() ->
+                jedis.sendCommand(Protocol.Command.SINTERCARD, "1", "myset", "LIMIT", "01"))
+                .hasMessage("ERR LIMIT can't be negative");
+        assertThatThrownBy(() ->
+                jedis.sendCommand(Protocol.Command.SINTERCARD, "1", "myset", "LIMIT", "-0"))
+                .hasMessage("ERR LIMIT can't be negative");
+        assertThatThrownBy(() ->
+                jedis.sendCommand(Protocol.Command.SINTERCARD,
+                        "1", "myset", "LIMIT", "9999999999999999999"))
+                .hasMessage("ERR LIMIT can't be negative");
+    }
+
+    /**
+     * Argument validation happens before any key is looked at, so a syntax
+     * error beats the WRONGTYPE a bad key would otherwise produce.
+     */
+    @TestTemplate
+    public void argumentErrorsWinOverWrongType(Jedis jedis) {
+        jedis.set("key1", "x");
+
+        assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.SINTERCARD, "0", "key1"))
+                .hasMessage("ERR numkeys should be greater than 0");
+        assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.SINTERCARD, "2", "key1"))
+                .hasMessage("ERR Number of keys can't be greater than number of args");
+        assertThatThrownBy(() ->
+                jedis.sendCommand(Protocol.Command.SINTERCARD, "1", "key1", "bar_arg"))
+                .hasMessage("ERR syntax error");
+        assertThatThrownBy(() ->
+                jedis.sendCommand(Protocol.Command.SINTERCARD, "1", "key1", "LIMIT", "-1"))
+                .hasMessage("ERR LIMIT can't be negative");
+    }
+
+    @TestTemplate
+    public void againstNonSetShouldThrowError(Jedis jedis) {
+        jedis.sadd("set", "a", "b", "c");
+        jedis.set("key1", "x");
+
+        assertThatThrownBy(() -> jedis.sintercard("key1"))
+                .hasMessage("WRONGTYPE Operation against a key holding the wrong kind of value");
+        assertThatThrownBy(() -> jedis.sintercard("set", "key1"))
+                .hasMessage("WRONGTYPE Operation against a key holding the wrong kind of value");
+        //The type of every key is checked, even once the intersection is known to be empty
+        assertThatThrownBy(() -> jedis.sintercard("key1", "noset"))
+                .hasMessage("WRONGTYPE Operation against a key holding the wrong kind of value");
+        assertThatThrownBy(() -> jedis.sintercard("noset", "key1"))
+                .hasMessage("WRONGTYPE Operation against a key holding the wrong kind of value");
+    }
+
+    @TestTemplate
+    public void againstNonExistingKey(Jedis jedis) {
+        assertThat(jedis.sintercard("non-existing-key")).isEqualTo(0);
+        assertThat(jedis.sintercard(0, "non-existing-key")).isEqualTo(0);
+        assertThat(jedis.sintercard(10, "non-existing-key")).isEqualTo(0);
+    }
+
+    @TestTemplate
+    public void withTwoSets(Jedis jedis) {
+        for (int i = 0; i < 200; i++) {
+            jedis.sadd("set1", String.valueOf(i));
+            jedis.sadd("set2", String.valueOf(i + 195));
+        }
+        jedis.sadd("set1", "foo");
+        jedis.sadd("set2", "foo");
+
+        assertThat(jedis.sintercard("set1", "set2")).isEqualTo(6);
+        assertThat(jedis.sintercard(0, "set1", "set2")).isEqualTo(6);
+        assertThat(jedis.sintercard(3, "set1", "set2")).isEqualTo(3);
+        assertThat(jedis.sintercard(10, "set1", "set2")).isEqualTo(6);
+    }
+
+    @TestTemplate
+    public void againstThreeSets(Jedis jedis) {
+        for (int i = 0; i < 200; i++) {
+            jedis.sadd("set1", String.valueOf(i));
+            jedis.sadd("set2", String.valueOf(i + 195));
+        }
+        jedis.sadd("set3", "199", "195", "1000", "2000");
+        jedis.sadd("set1", "foo");
+        jedis.sadd("set2", "foo");
+        jedis.sadd("set3", "foo");
+
+        assertThat(jedis.sintercard("set1", "set2", "set3")).isEqualTo(3);
+        assertThat(jedis.sintercard(0, "set1", "set2", "set3")).isEqualTo(3);
+        assertThat(jedis.sintercard(2, "set1", "set2", "set3")).isEqualTo(2);
+        assertThat(jedis.sintercard(10, "set1", "set2", "set3")).isEqualTo(3);
+    }
+
+    @TestTemplate
+    public void emptyIntersectionIsZeroWhateverTheLimit(Jedis jedis) {
+        jedis.sadd("e1", "x");
+        jedis.sadd("e2", "y");
+
+        assertThat(jedis.sintercard("e1", "e2")).isEqualTo(0);
+        assertThat(jedis.sintercard(5, "e1", "e2")).isEqualTo(0);
+    }
+
+    @TestTemplate
+    public void repeatedKeyIntersectsWithItself(Jedis jedis) {
+        jedis.sadd("myset", "a", "b", "c");
+
+        assertThat(jedis.sintercard("myset", "myset")).isEqualTo(3);
+        assertThat(jedis.sintercard("myset", "myset", "myset")).isEqualTo(3);
+        assertThat(jedis.sintercard(2, "myset", "myset")).isEqualTo(2);
+    }
+
+    @TestTemplate
+    public void limitIsCaseInsensitiveAndTheLastOneWins(Jedis jedis) {
+        jedis.sadd("myset", "a", "b", "c");
+        jedis.sadd("myset2", "a", "b", "c");
+
+        assertThat(jedis.sendCommand(Protocol.Command.SINTERCARD,
+                "2", "myset", "myset2", "LiMiT", "0")).isEqualTo(3L);
+        assertThat(jedis.sendCommand(Protocol.Command.SINTERCARD,
+                "2", "myset", "myset2", "LIMIT", "0", "LIMIT", "1")).isEqualTo(1L);
+    }
+
+    @TestTemplate
+    public void doesNotCreateOrModifyKeys(Jedis jedis) {
+        jedis.sadd("myset", "a", "b", "c");
+        jedis.sadd("myset2", "b", "c", "d");
+
+        assertThat(jedis.sintercard("myset", "myset2")).isEqualTo(2);
+        assertThat(jedis.keys("*")).containsExactlyInAnyOrder("myset", "myset2");
+    }
+}


### PR DESCRIPTION
Implements `SINTERCARD`.

## Behaviour

Pinned against a `redis:7.4-alpine` container rather than the docs, since the
argument-validation order is counter-intuitive and largely unspecified:

- **All validation happens before any key is touched**, so a syntax error is
  reported in preference to the `WRONGTYPE` a bad key would otherwise raise —
  `SINTERCARD 1 stringkey bar_arg` is a syntax error, not `WRONGTYPE`.
- Validation order is numkeys → numkeys-vs-argument-count → `LIMIT`/syntax.
- `LIMIT` may be repeated and the last one wins; `LIMIT 0` means unlimited.
- The type of *every* key is checked even once the intersection is known to be
  empty: `SINTERCARD 2 nokey stringkey` → `WRONGTYPE`.
- Error strings match exactly: `numkeys should be greater than 0`,
  `Number of keys can't be greater than number of args`, `syntax error`,
  `LIMIT can't be negative`.

`SInterCard` delegates to `new SInter(base(), keys).getIntersection()` — the
same reuse pattern `SInterStore` already uses — so no intersection logic is
duplicated and `SInter` itself is unchanged. It deliberately does *not* extend
`SInter`: its parameter layout differs (numkeys first, `LIMIT` last), so it
would inherit a `getIntersection()` that reads the wrong arguments.

## Stricter integer parsing

`SINTERCARD` rejects `+1`, `01`, `-0` and `" 1"` for both `numkeys` and
`LIMIT`. Implementing that locally would have papered over a general problem:
Redis parses integer arguments with `string2ll`, which is stricter than Java's
`Long.parseLong`/`Integer.parseInt`. Verified against a real server — all of
these error and previously did not on the mock:

```
INCRBY n +1        EXPIRE n 01        LRANGE mylist +0 -1
DECRBY n 01        SETBIT bk +1 1     GETBIT bk 01
```

So the grammar lives once in `Utils` instead:

- New `Utils.parseRedisLong(String) → OptionalLong` — the `string2ll` grammar,
  returning empty rather than throwing so each caller can raise its own
  command's error message.
- `convertToLong`, `convertToInteger` and `convertToNonNegativeInteger` all
  delegate to it. `convertToInteger` now range-checks int bounds explicitly
  rather than relying on `Integer.parseInt`.
- `ExpirationTimeParam` had its own raw `Long.parseLong` and so bypassed
  `Utils` entirely; `EXPIRE`/`PEXPIRE` now route through the shared parser too.

This makes 23 existing call sites stricter. It is a fidelity improvement in
every case I checked, and the whole suite passes, but it is a behaviour change
beyond the stated scope and is the part most worth a careful look.

## Tests

- `SInterCardTest` — 14 comparison-test methods: arity, numkeys, syntax and
  `LIMIT` errors, error precedence vs `WRONGTYPE`, non-existing keys, two- and
  three-set cardinality with limits, repeated keys, empty intersections, and
  that the command creates no keys.
- `StrictIntegerParsingTest` — 4 methods covering the shared grammar across
  `INCRBY`/`DECRBY`/`EXPIRE`/`LRANGE`/`SETBIT`/`GETBIT`, plus a guard that
  well-formed integers (including negatives and `0`) still parse.
- Both were confirmed red against the mock and green against real Redis before
  the implementation was written. `StrictIntegerParsingTest` is what caught the
  `ExpirationTimeParam` bypass.
- Full suite green: 2000 tests.

## Native tests

Uncommented all five `SINTERCARD` blocks in `native_tests/.../type/set.tcl`
(illegal arguments, non-set, non-existing key, and the two `$type`-parameterised
two-set/three-set cases), byte-for-byte as upstream. Not run locally.
