### PR TITLE
build: bump testcontainers to 1.21.4 to support newer Docker Engines

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <junit.version>6.1.3</junit.version>
         <assertj.version>3.27.7</assertj.version>
         <jedis.version>7.5.3</jedis.version>
-        <testcontainers.version>1.21.3</testcontainers.version>
+        <testcontainers.version>1.21.4</testcontainers.version>
         <spotbugs.version>4.10.4.0</spotbugs.version>
         <slf4j.version>2.0.18</slf4j.version>
         <java.version>1.8</java.version>


### PR DESCRIPTION
With this PR we'll update testcontainers dependency as version 1.21.3 fails to talk to Docker Engine 29. At this point there is a version 2.0.5 available as well but that's a slightly bigger change.