### PR TITLE
fix: hash commands incorrectly clearing ttls

### DIFF
--- a/src/main/java/com/github/fppt/jedismock/operations/hashes/HIncrBy.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/hashes/HIncrBy.java
@@ -23,7 +23,7 @@ class HIncrBy extends AbstractRedisOperation {
         if (foundValue != null) {
             numericValue = Math.addExact(convertToLong(new String(foundValue.data())), numericValue);
         }
-        base().putSlice(key1, key2, Slice.create(String.valueOf(numericValue)), -1L);
+        base().putSlice(key1, key2, Slice.create(String.valueOf(numericValue)), null);
         return Response.integer(numericValue);
     }
 

--- a/src/main/java/com/github/fppt/jedismock/operations/hashes/HIncrByFloat.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/hashes/HIncrByFloat.java
@@ -56,7 +56,7 @@ class HIncrByFloat extends HIncrBy {
         separator.setDecimalSeparator('.');
         DecimalFormat formatter = new DecimalFormat("#.#################", separator);
         Slice res = Slice.create(formatter.format(numericValue));
-        base().putSlice(key1, key2, res, -1L);
+        base().putSlice(key1, key2, res, null);
         return Response.bulkString(res);
     }
 

--- a/src/main/java/com/github/fppt/jedismock/operations/hashes/HSetNX.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/hashes/HSetNX.java
@@ -15,7 +15,7 @@ class HSetNX extends HSet {
     Slice hsetValue(Slice key1, Slice key2, Slice value){
         Slice foundValue = base().getSlice(key1, key2);
         if(foundValue == null){
-            base().putSlice(key1, key2, value, -1L);
+            base().putSlice(key1, key2, value, null);
         }
         return foundValue;
     }

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/hashes/HashOperationsTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/hashes/HashOperationsTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
 
 import static org.assertj.core.api.Assertions.within;
+import static org.assertj.core.api.InstanceOfAssertFactories.LONG;
 
 @ExtendWith(ComparisonBase.class)
 public class HashOperationsTest {
@@ -201,6 +202,17 @@ public class HashOperationsTest {
     }
 
     @TestTemplate
+    public void hIncrByFloatDoesNotClearHashTtl(Jedis jedis) {
+        jedis.hset(HASH, FIELD_1, VALUE_1);
+        jedis.expire(HASH, 200);
+        assertThat(jedis.ttl(HASH)).isBetween(190L, 201L);
+
+        assertThat(jedis.hsetnx(HASH, FIELD_2, VALUE_2)).isEqualTo(1);
+
+        assertThat(jedis.ttl(HASH)).isBetween(180L, 201L);
+    }
+
+    @TestTemplate
     public void whenIncrementingWithHIncrByFloat_ensureValuesAreCorrect(Jedis jedis) {
         jedis.hset("key", "subkey", "0");
         jedis.hincrByFloat("key", "subkey", 1.);
@@ -225,6 +237,34 @@ public class HashOperationsTest {
                 .isInstanceOf(JedisDataException.class);
         assertThatThrownBy(() -> jedis.hincrByFloat("key", "subkey", 1.5))
                 .isInstanceOf(JedisDataException.class);
+    }
+
+    @TestTemplate
+    public void hIncrByDoesNotClearTtls(Jedis jedis) {
+        jedis.hset(HASH, FIELD_1, "1");
+        jedis.hexpire(HASH, 100, FIELD_1);
+        jedis.expire(HASH, 200);
+        assertThat(jedis.httl(HASH, FIELD_1)).singleElement().asInstanceOf(LONG).isBetween(90L, 101L);
+        assertThat(jedis.ttl(HASH)).isBetween(190L, 201L);
+
+        assertThat(jedis.hincrBy(HASH, FIELD_1, 3)).isEqualTo(4);
+
+        assertThat(jedis.httl(HASH, FIELD_1)).singleElement().asInstanceOf(LONG).isBetween(90L, 101L);
+        assertThat(jedis.ttl(HASH)).isBetween(180L, 201L);
+    }
+
+    @TestTemplate
+    public void hIncrByFloatDoesNotClearTtls(Jedis jedis) {
+        jedis.hset(HASH, FIELD_1, "1.0");
+        jedis.hexpire(HASH, 100, FIELD_1);
+        jedis.expire(HASH, 200);
+        assertThat(jedis.httl(HASH, FIELD_1)).singleElement().asInstanceOf(LONG).isBetween(90L, 101L);
+        assertThat(jedis.ttl(HASH)).isBetween(190L, 201L);
+
+        assertThat(jedis.hincrByFloat(HASH, FIELD_1, 3.5)).isEqualTo(4.5);
+
+        assertThat(jedis.httl(HASH, FIELD_1)).singleElement().asInstanceOf(LONG).isBetween(90L, 101L);
+        assertThat(jedis.ttl(HASH)).isBetween(180L, 201L);
     }
 
     @TestTemplate


### PR DESCRIPTION
hincrby, hincrbyfloag and hsetnx all incorrectly cleared the
existing ttl of the hash key and field. now they are left as is.
