### PR TITLE
fix: hset not clearing field ttl

### DIFF
--- a/src/main/java/com/github/fppt/jedismock/operations/hashes/HSet.java
+++ b/src/main/java/com/github/fppt/jedismock/operations/hashes/HSet.java
@@ -17,7 +17,7 @@ class HSet extends AbstractRedisOperation {
 
     Slice hsetValue(Slice key1, Slice key2, Slice value) {
         Slice foundValue = base().getSlice(key1, key2);
-        base().putSlice(key1, key2, value, null);
+        base().putSlice(key1, key2, value, -1L);
         return foundValue;
     }
 

--- a/src/main/java/com/github/fppt/jedismock/storage/ExpiringKeyValueStorage.java
+++ b/src/main/java/com/github/fppt/jedismock/storage/ExpiringKeyValueStorage.java
@@ -173,7 +173,8 @@ public class ExpiringKeyValueStorage extends ExpiringStorage {
             mapByKey = getRMHash(key1);
         }
         mapByKey.put(key2, value);
-        configureTTL(key1, ttl);
+        configureTTL(key1, null);
+        mapByKey.configureTTL(key2, ttl);
     }
 
     private RMHash getRMHash(Slice key) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/hashes/HashOperationsTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/hashes/HashOperationsTest.java
@@ -88,6 +88,26 @@ public class HashOperationsTest {
     }
 
     @TestTemplate
+    public void hSetClearsFieldTtl(Jedis jedis) {
+        jedis.hset(HASH, Map.of(FIELD_1, VALUE_1, FIELD_2, VALUE_2));
+        jedis.hexpire(HASH, 200, FIELD_1);
+        jedis.hexpire(HASH, 100, FIELD_2);
+        assertThat(jedis.hmget(HASH, FIELD_1, FIELD_2)).contains(VALUE_1, VALUE_2);
+        assertThat(jedis.httl(HASH, FIELD_1, FIELD_2)).satisfiesExactly(
+                ttl -> assertThat(ttl).isBetween(190L, 201L),
+                ttl -> assertThat(ttl).isBetween(90L, 101L)
+        );
+
+        assertThat(jedis.hset(HASH, FIELD_1, VALUE_2)).isEqualTo(0);
+
+        assertThat(jedis.hget(HASH, FIELD_1)).isEqualTo(VALUE_2);
+        assertThat(jedis.httl(HASH, FIELD_1, FIELD_2)).satisfiesExactly(
+                ttl -> assertThat(ttl).isEqualTo(-1),
+                ttl -> assertThat(ttl).isBetween(80L, 101L)
+        );
+    }
+
+    @TestTemplate
     public void whenHGetAll_EnsureAllKeysAndValuesReturned(Jedis jedis) {
         jedis.hset(HASH, FIELD_1, VALUE_1);
         jedis.hset(HASH, FIELD_2, VALUE_2);


### PR DESCRIPTION
hset should clear each set field's ttl but was not. also fixes a latent
bug in ExpiringKeyValueStorage.put that configured the passed in ttl on
the hash key rather than the field key. Note that `configureTTL` still
needs to be called on the hash key so ttl calls on the hash key itself
still work correctly.
