### PR TITLE
upgrade ComparisonBase container to redis 8.0

### DIFF
--- a/src/test/java/com/github/fppt/jedismock/comparisontests/ComparisonBase.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/ComparisonBase.java
@@ -23,7 +23,7 @@ public class ComparisonBase implements TestTemplateInvocationContextProvider,
         BeforeAllCallback, AfterAllCallback {
     private static RedisServer fakeServer;
 
-    private static final GenericContainer<?> redis = new GenericContainer<>("redis:7.4-alpine")
+    private static final GenericContainer<?> redis = new GenericContainer<>("redis:8.0-alpine")
             .withExposedPorts(6379);
 
 


### PR DESCRIPTION
groundwork to implement hgetdel and hsetex.

fortunately fully compatible with existing tests. discussion [here](https://github.com/fppt/jedis-mock/issues/840)