### PR TITLE
flushAll before every ComparisonBase test.

### DIFF
--- a/src/test/java/com/github/fppt/jedismock/comparisontests/ComparisonBase.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/ComparisonBase.java
@@ -4,6 +4,7 @@ import com.github.fppt.jedismock.RedisServer;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.Extension;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterContext;
@@ -94,7 +95,9 @@ public class ComparisonBase implements TestTemplateInvocationContextProvider,
                 public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
                     return parameterContext.getParameter().getType() == Jedis.class ? jedis : hostAndPort;
                 }
-            }, (AfterEachCallback) context ->
+            },
+            (BeforeEachCallback) context -> jedis.flushAll(),
+            (AfterEachCallback) context ->
             {
                 if (context.getExecutionException().isPresent() &&
                         context.getExecutionException().get().getMessage().startsWith(TestErrorMessages.DEADLOCK_ERROR_MESSAGE)) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/StrictIntegerParsingTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/StrictIntegerParsingTest.java
@@ -23,7 +23,6 @@ public class StrictIntegerParsingTest {
 
     @BeforeEach
     public void setUp(Jedis jedis) {
-        jedis.flushAll();
         jedis.set("n", "10");
         jedis.rpush("mylist", "a", "b", "c");
     }

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/bitmaps/BitMapsOperationsTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/bitmaps/BitMapsOperationsTest.java
@@ -20,7 +20,6 @@ public class BitMapsOperationsTest {
 
     @BeforeEach
     public void setUp(Jedis jedis) {
-        jedis.flushAll();
         for (int i : bits) {
             jedis.setbit("bm", i, true);
         }

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/connection/AdvanceConnectionOperationsTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/connection/AdvanceConnectionOperationsTest.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.connection;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -11,11 +10,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(ComparisonBase.class)
 public class AdvanceConnectionOperationsTest {
-
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     @TestTemplate
     public void whenChangingBetweenRedisDBS_EnsureChangesAreMutuallyExclusive(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/hashes/HGetDelOperationTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/hashes/HGetDelOperationTest.java
@@ -2,7 +2,6 @@ package com.github.fppt.jedismock.comparisontests.hashes;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
 import com.github.fppt.jedismock.comparisontests.notifications.NotificationCollector;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.HostAndPort;
@@ -29,11 +28,6 @@ public class HGetDelOperationTest {
     private final String VALUE_2 = "value2";
     private final String FIELD_3 = "field3";
     private final String VALUE_3 = "value3";
-
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     @TestTemplate
     public void whenHGetDelSingleField_EnsureDeletedValueIsReturned(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/hashes/HKeysOperation.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/hashes/HKeysOperation.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.hashes;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -14,10 +13,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(ComparisonBase.class)
 public class HKeysOperation {
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     @TestTemplate
     void hkeysUnknownKey(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/hashes/HashOperationsTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/hashes/HashOperationsTest.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.hashes;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -31,11 +30,6 @@ public class HashOperationsTest {
     private final String VALUE_2 = "value2";
     private final String FIELD_3 = "field3";
     private final String VALUE_3 = "value3";
-
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     @TestTemplate
     public void whenIncrementingSet_ensureValuesAreCorrect(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/hashes/HashValuesExpirationTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/hashes/HashValuesExpirationTest.java
@@ -22,7 +22,6 @@ import static org.assertj.core.api.Assertions.*;
 public class HashValuesExpirationTest {
     @BeforeEach
     public void setUp(Jedis jedis) {
-        jedis.flushAll();
         jedis.hset("mykey", "field1", "hello");
         jedis.hset("mykey", "field2", "world");
     }

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/hashes/TestHDel.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/hashes/TestHDel.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.hashes;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -14,10 +13,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @ExtendWith(ComparisonBase.class)
 public class TestHDel {
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushDB();
-    }
 
     @TestTemplate
     public void whenHDeleting_EnsureValuesAreRemoved(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/hashes/TestHScan.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/hashes/TestHScan.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.hashes;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -18,12 +17,6 @@ import static redis.clients.jedis.params.ScanParams.SCAN_POINTER_START;
 public class TestHScan {
 
     private static final String key = "hscankey";
-
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushDB();
-    }
-
 
     @TestTemplate
     public void hscanReturnsAllValues(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/hashes/TestHStrlen.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/hashes/TestHStrlen.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.hashes;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -10,10 +9,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(ComparisonBase.class)
 public class TestHStrlen {
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushDB();
-    }
 
     @TestTemplate
     public void hstrlenReturnsLengthOfFields(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/hyperloglog/HLLOperationsTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/hyperloglog/HLLOperationsTest.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.hyperloglog;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -12,10 +11,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @ExtendWith(ComparisonBase.class)
 public class HLLOperationsTest {
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     @TestTemplate
     public void testPfadd(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/keys/CopyTests.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/keys/CopyTests.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.keys;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -14,12 +13,6 @@ public class CopyTests {
     private final String dstKey = "second";
     private final int dstDb = 11;
     private final String val = "abracadabra";
-
-
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     @TestTemplate
     public void successfulCopySameDb(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/keys/KeysOperationsTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/keys/KeysOperationsTest.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.keys;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -12,11 +11,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(ComparisonBase.class)
 public class KeysOperationsTest {
-
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     @TestTemplate
     public void whenGettingKeys_EnsureCorrectKeysAreReturned(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/keys/MoveTests.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/keys/MoveTests.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.keys;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -13,12 +12,6 @@ public class MoveTests {
     private final String srcKey = "first";
     private final int dstDb = 11;
     private final String val = "abracadabra";
-
-
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     @TestTemplate
     public void successfulMove(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/keys/TestExpiration.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/keys/TestExpiration.java
@@ -2,7 +2,6 @@ package com.github.fppt.jedismock.comparisontests.keys;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
 import org.assertj.core.api.SoftAssertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -15,10 +14,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(ComparisonBase.class)
 public class TestExpiration {
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     @TestTemplate
     public void whenGettingKeys_EnsureExpiredKeysAreNotReturned(Jedis jedis) throws InterruptedException {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/keys/TestPersist.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/keys/TestPersist.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.keys;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -10,10 +9,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(ComparisonBase.class)
 public class TestPersist {
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushDB();
-    }
 
     @TestTemplate
     public void testPersistExistingWithTTL(Jedis jedis) throws Exception {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/keys/TestScan.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/keys/TestScan.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.keys;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -13,11 +12,6 @@ import static redis.clients.jedis.params.ScanParams.SCAN_POINTER_START;
 
 @ExtendWith(ComparisonBase.class)
 public class TestScan {
-
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushDB();
-    }
 
     @TestTemplate
     public void scanReturnsAllKey(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/keys/TestType.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/keys/TestType.java
@@ -12,7 +12,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestType {
     @BeforeEach
     void setUp(Jedis jedis) {
-        jedis.flushDB();
         jedis.set("key", "string");
         jedis.lpush("lkey", "value1", "value2");
         jedis.sadd("skey", "val1", "val2");

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/lists/BlockingOperationsTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/lists/BlockingOperationsTest.java
@@ -32,8 +32,7 @@ public class BlockingOperationsTest {
     private Jedis blockedClient;
 
     @BeforeEach
-    public void setUp(Jedis jedis, HostAndPort hostAndPort) {
-        jedis.flushAll();
+    public void setUp(HostAndPort hostAndPort) {
         blockedClient = new Jedis(hostAndPort.getHost(), hostAndPort.getPort());
         blockingThread = Executors.newSingleThreadExecutor();
     }

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/lists/LInsertTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/lists/LInsertTest.java
@@ -19,7 +19,6 @@ public class LInsertTest {
 
     @BeforeEach
     public void setUp(Jedis jedis) {
-        jedis.flushAll();
         jedis.rpush(key, "1", "2", "3", "3", "4");
     }
 

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/lists/LPosTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/lists/LPosTest.java
@@ -20,8 +20,6 @@ public class LPosTest {
 
     @BeforeEach
     public void setUp(Jedis jedis) {
-        jedis.flushAll();
-
         jedis.rpush(key, "a", "b", "c", "1", "2", "3", "c", "c");
     }
 

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/lists/LPushXRPushXTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/lists/LPushXRPushXTest.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.lists;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -12,11 +11,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class LPushXRPushXTest {
     private final static String lpushxKey = "lpushx_test_key";
     private final static String rpushxKey = "rpushx_test_key";
-
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     @TestTemplate
     public void whenUsingLPushX_EnsureReturnsZeroOnNonList(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/lists/LRangeTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/lists/LRangeTest.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.lists;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -10,10 +9,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(ComparisonBase.class)
 public class LRangeTest {
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     @TestTemplate
     public void whenUsingLRange_checkOutOfRangeNegativeEndIndex(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/lists/LSetTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/lists/LSetTest.java
@@ -16,7 +16,6 @@ public class LSetTest {
     private static final String key = "lset_list_key";
     @BeforeEach
     public void setUp(Jedis jedis) {
-        jedis.flushAll();
         jedis.rpush(key, "1", "2", "3");
     }
 

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/lists/ListOperationsTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/lists/ListOperationsTest.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.lists;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -14,11 +13,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @ExtendWith(ComparisonBase.class)
 public class ListOperationsTest {
-
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     @TestTemplate
     public void whenUsingRpop_EnsureTheLastElementPushedIsReturned(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/lists/ListPopTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/lists/ListPopTest.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.lists;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -11,11 +10,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @ExtendWith(ComparisonBase.class)
 public class ListPopTest {
-
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     @TestTemplate
     public void whenUsingListPop_ensureCheckForType(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/lists/RPopLPushTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/lists/RPopLPushTest.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.lists;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -12,11 +11,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @ExtendWith(ComparisonBase.class)
 public class RPopLPushTest {
-
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     @TestTemplate
     public void whenUsingRRopLPush_ensureDontPopOnInvalidTargetType(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/lists/SortTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/lists/SortTest.java
@@ -32,8 +32,6 @@ public class SortTest {
 
     @BeforeEach
     public void setUp(Jedis jedis) {
-        jedis.flushAll();
-
         jedis.rpush(key, "a", "b", "c", "1", "2", "3", "c", "c");
         jedis.rpush(numerical_sort_key, "5", "4", "3", "2", "1");
     }

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/lists/TestLTrim.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/lists/TestLTrim.java
@@ -17,7 +17,6 @@ public class TestLTrim {
 
     @BeforeEach
     public void setUp(Jedis jedis) {
-        jedis.flushAll();
         jedis.del(key);
         jedis.rpush(key, "e0");
         jedis.rpush(key, "e1");

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/lists/WatchTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/lists/WatchTest.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.lists;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.HostAndPort;
@@ -12,11 +11,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(ComparisonBase.class)
 public class WatchTest {
-
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     @TestTemplate
     public void whenUsingPop_ensureAffectsWatchedKey(Jedis jedis, HostAndPort hostAndPort) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/notifications/ListKeyspaceNotificationsTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/notifications/ListKeyspaceNotificationsTest.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.notifications;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.HostAndPort;
@@ -20,11 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @ExtendWith(ComparisonBase.class)
 public class ListKeyspaceNotificationsTest {
-
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     @TestTemplate
     public void pushCommandsPublishOneEventPerCommand(Jedis jedis, HostAndPort hostAndPort) throws Exception {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/notifications/NewKeyKeyspaceNotificationsTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/notifications/NewKeyKeyspaceNotificationsTest.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.notifications;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.HostAndPort;
@@ -20,11 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @ExtendWith(ComparisonBase.class)
 public class NewKeyKeyspaceNotificationsTest {
-
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     @TestTemplate
     public void everyTypeOfCreationPublishesNewOnce(Jedis jedis, HostAndPort hostAndPort) throws Exception {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/notifications/StreamKeyspaceNotificationsTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/notifications/StreamKeyspaceNotificationsTest.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.notifications;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.HostAndPort;
@@ -22,11 +21,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @ExtendWith(ComparisonBase.class)
 public class StreamKeyspaceNotificationsTest {
-
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     @TestTemplate
     public void streamWritesPublishTheirEvents(Jedis jedis, HostAndPort hostAndPort) throws Exception {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/scripting/EvalShaTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/scripting/EvalShaTest.java
@@ -2,7 +2,6 @@ package com.github.fppt.jedismock.comparisontests.scripting;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
 import com.github.fppt.jedismock.operations.scripting.Script;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -12,11 +11,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @ExtendWith(ComparisonBase.class)
 class EvalShaTest {
-
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     @TestTemplate
     public void evalShaWorksLowercase(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/scripting/EvalTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/scripting/EvalTest.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.scripting;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -19,10 +18,6 @@ import static org.assertj.core.api.InstanceOfAssertFactories.LIST;
 
 @ExtendWith(ComparisonBase.class)
 public class EvalTest {
-    @BeforeEach
-    void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     @TestTemplate
     void evalTest(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/scripting/ScriptTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/scripting/ScriptTest.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.scripting;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -10,11 +9,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(ComparisonBase.class)
 class ScriptTest {
-
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     @TestTemplate
     public void loadTest(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/server/ServerOperationsTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/server/ServerOperationsTest.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.server;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -14,11 +13,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(ComparisonBase.class)
 public class ServerOperationsTest {
-
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     @TestTemplate
     public void whenUsingFlushall_EnsureEverythingIsDeleted(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/sets/SDiffSDiffStoreTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/sets/SDiffSDiffStoreTest.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.sets;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -15,10 +14,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(ComparisonBase.class)
 public class SDiffSDiffStoreTest {
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     @TestTemplate
     public void sDiffTwoSetsTest(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/sets/SInterCardTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/sets/SInterCardTest.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.sets;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -12,11 +11,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @ExtendWith(ComparisonBase.class)
 public class SInterCardTest {
-
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     @TestTemplate
     public void wrongNumberOfArguments(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/sets/SInterSInterStoreTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/sets/SInterSInterStoreTest.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.sets;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -15,10 +14,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(ComparisonBase.class)
 public class SInterSInterStoreTest {
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     @TestTemplate
     public void whenUsingHsinter_EnsureSetIntersectionIsReturned(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/sets/SMIsMemberTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/sets/SMIsMemberTest.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.sets;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -14,10 +13,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @ExtendWith(ComparisonBase.class)
 public class SMIsMemberTest {
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     @TestTemplate
     public void simpleCase(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/sets/SRandMemberTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/sets/SRandMemberTest.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.sets;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -17,10 +16,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(ComparisonBase.class)
 public class SRandMemberTest {
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     @TestTemplate
     void randMemberReturnsARandomElementOfTheSet(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/sets/SScanTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/sets/SScanTest.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.sets;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -17,11 +16,6 @@ import static redis.clients.jedis.params.ScanParams.SCAN_POINTER_START;
 @ExtendWith(ComparisonBase.class)
 public class SScanTest {
     private static final String key = "sscankey";
-
-    @BeforeEach
-    void setUp(Jedis jedis) {
-        jedis.flushDB();
-    }
 
     @TestTemplate
     public void sscanReturnsAllValues(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/sets/SUnionSUnionStoreTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/sets/SUnionSUnionStoreTest.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.sets;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -15,10 +14,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(ComparisonBase.class)
 public class SUnionSUnionStoreTest {
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     @TestTemplate
     public void sUnionTest(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/sets/SetOperationsTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/sets/SetOperationsTest.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.sets;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -16,11 +15,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @ExtendWith(ComparisonBase.class)
 public class SetOperationsTest {
-
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     @TestTemplate
     public void whenAddingToASet_EnsureTheSetIsUpdated(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/SortedSetOperationsTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/SortedSetOperationsTest.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.sortedsets;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -17,11 +16,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @ExtendWith(ComparisonBase.class)
 public class SortedSetOperationsTest {
-
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     @TestTemplate
     public void zcardEmptyKey(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestBZMPop.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestBZMPop.java
@@ -35,8 +35,7 @@ public class TestBZMPop {
     private static final String ZSET_KEY = "myzset";
 
     @BeforeEach
-    public void setUp(Jedis jedis, HostAndPort hostAndPort) {
-        jedis.flushAll();
+    public void setUp(HostAndPort hostAndPort) {
         blockedClient = new Jedis(hostAndPort.getHost(), hostAndPort.getPort());
         blockedClient2 = new Jedis(hostAndPort.getHost(), hostAndPort.getPort());
         blockingThread = Executors.newFixedThreadPool(4);

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestBZPopMax.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestBZPopMax.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.sortedsets;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -15,12 +14,6 @@ public class TestBZPopMax {
 
     private static final String ZSET_KEY_1 = "myzset";
     private static final String ZSET_KEY_2 = "ztmp";
-
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushDB();
-
-    }
 
     @TestTemplate
     public void testBZPopMaxFromSingleExistingSortedSet(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestBZPopMin.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestBZPopMin.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.sortedsets;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -15,12 +14,6 @@ public class TestBZPopMin {
 
     private static final String ZSET_KEY_1 = "myzset";
     private static final String ZSET_KEY_2 = "ztmp";
-
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushDB();
-
-    }
 
     @TestTemplate
     public void testBZPopMinFromSingleExistingSortedSet(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZCount.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZCount.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.sortedsets;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -14,11 +13,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class TestZCount {
 
     private static final String ZSET_KEY = "myzset";
-
-    @BeforeEach
-    public void clearKey(Jedis jedis) {
-        jedis.del(ZSET_KEY);
-    }
 
     @TestTemplate
     public void whenUsingZCount_EnsureItReturnsZeroForNonDefinedKey(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZDiff.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZDiff.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.sortedsets;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -20,11 +19,6 @@ public class TestZDiff {
 
     private static final String ZSET_KEY_1 = "myzset";
     private static final String ZSET_KEY_2 = "ztmp";
-
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     @TestTemplate
     public void testZDiffNotExistKeyToNotExistDest(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZDiffStore.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZDiffStore.java
@@ -17,7 +17,6 @@ public class TestZDiffStore {
 
     @BeforeEach
     public void setUp(Jedis jedis) {
-        jedis.flushDB();
         jedis.zadd(ZSET_KEY_1, 0, "a");
         jedis.zadd(ZSET_KEY_1, 1, "b");
         jedis.zadd(ZSET_KEY_1, 2, "c");

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZInter.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZInter.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.sortedsets;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -17,11 +16,6 @@ public class TestZInter {
 
     private static final String ZSET_KEY_1 = "myzset";
     private static final String ZSET_KEY_2 = "ztmp";
-
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     @TestTemplate
     public void testZInterNotExistKeyToNotExistDest(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZInterCard.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZInterCard.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.sortedsets;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -14,11 +13,6 @@ public class TestZInterCard {
 
     private static final String ZSET_KEY_1 = "myzset";
     private static final String ZSET_KEY_2 = "ztmp";
-
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     @TestTemplate
     public void testZInterCardNotExistKeyToNotExistDest(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZInterStore.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZInterStore.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.sortedsets;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -23,11 +22,6 @@ public class TestZInterStore {
     private static final String ZSET_KEY_1 = "myzset";
     private static final String ZSET_KEY_2 = "ztmp";
     private static final String ZSET_KEY_OUT = "zout";
-
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     @TestTemplate
     public void testZInterStoreNotExistKeyToNotExistDest(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZLexCount.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZLexCount.java
@@ -19,7 +19,6 @@ public class TestZLexCount {
 
     @BeforeEach
     public void setUp(Jedis jedis) {
-        jedis.flushDB();
         Map<String, Double> members = new HashMap<>();
         members.put("alpha", 0d);
         members.put("bar", 0d);

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZMPop.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZMPop.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.sortedsets;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -22,12 +21,6 @@ import static redis.clients.jedis.args.SortedSetOption.MIN;
 public class TestZMPop {
 
     private static final String ZSET_KEY = "myzset";
-
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushDB();
-
-    }
 
     @TestTemplate
     public void testZMPopKeyNotExist(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZMScore.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZMScore.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.sortedsets;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -15,11 +14,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestZMScore {
 
     private static final String ZSET_KEY = "myzset";
-
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     @TestTemplate
     public void testZScoreNotExistKey(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZPopMax.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZPopMax.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.sortedsets;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -17,12 +16,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class TestZPopMax {
 
     private static final String ZSET_KEY = "myzset";
-
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushDB();
-
-    }
 
     @TestTemplate
     public void testZPopMaxFromSingleKey(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZPopMin.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZPopMin.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.sortedsets;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -17,12 +16,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class TestZPopMin {
 
     private static final String ZSET_KEY = "myzset";
-
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushDB();
-
-    }
 
     @TestTemplate
     public void testZPopMinFromSingleKey(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZRange.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZRange.java
@@ -25,7 +25,6 @@ public class TestZRange {
 
     @BeforeEach
     public void setUp(Jedis jedis) {
-        jedis.flushDB();
         jedis.zadd(ZSET_KEY, 2, "aaaa");
         jedis.zadd(ZSET_KEY, 3, "bbbb");
         jedis.zadd(ZSET_KEY, 1, "cccc");

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZRangeByLex.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZRangeByLex.java
@@ -21,7 +21,6 @@ public class TestZRangeByLex {
 
     @BeforeEach
     public void setUp(Jedis jedis) {
-        jedis.flushDB();
         Map<String, Double> members = new HashMap<>();
         members.put("bbb", 0d);
         members.put("ddd", 0d);

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZRangeByScore.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZRangeByScore.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.sortedsets;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -18,11 +17,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class TestZRangeByScore {
 
     private static final String ZSET_KEY = "myzset";
-
-    @BeforeEach
-    public void clearKey(Jedis jedis) {
-        jedis.flushDB();
-    }
 
     @TestTemplate
     public void whenUsingZrangeByScore_EnsureItReturnsEmptySetForNonDefinedKey(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZRangeStore.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZRangeStore.java
@@ -25,7 +25,6 @@ public class TestZRangeStore {
 
     @BeforeEach
     public void setUp(Jedis jedis) {
-        jedis.flushDB();
         jedis.zadd(ZSET_KEY, 1, "a");
         jedis.zadd(ZSET_KEY, 2, "b");
         jedis.zadd(ZSET_KEY, 3, "c");

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZRangeWithByLexArg.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZRangeWithByLexArg.java
@@ -23,7 +23,6 @@ public class TestZRangeWithByLexArg {
 
     @BeforeEach
     public void setUp(Jedis jedis) {
-        jedis.flushDB();
         Map<String, Double> members = new HashMap<>();
         members.put("bbb", 0d);
         members.put("ddd", 0d);

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZRangeWithByScoreArg.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZRangeWithByScoreArg.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.sortedsets;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -19,11 +18,6 @@ import static redis.clients.jedis.params.ZRangeParams.zrangeByScoreParams;
 public class TestZRangeWithByScoreArg {
 
     private static final String ZSET_KEY = "myzset";
-
-    @BeforeEach
-    public void clearKey(Jedis jedis) {
-        jedis.del(ZSET_KEY);
-    }
 
     @TestTemplate
     public void whenUsingZrangeByScore_EnsureItReturnsEmptySetForNonDefinedKey(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZRank.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZRank.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.sortedsets;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -12,11 +11,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestZRank {
 
     private static final String ZSET_KEY = "myzset";
-
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushDB();
-    }
 
     @TestTemplate
     public void testZRankGetFirstRank(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZRem.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZRem.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.sortedsets;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -16,11 +15,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestZRem {
 
     private static final String ZSET_KEY = "myzset";
-
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushDB();
-    }
 
     @TestTemplate
     public void zRemRemovesKey(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZRemRangeByLex.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZRemRangeByLex.java
@@ -18,7 +18,6 @@ public class TestZRemRangeByLex {
 
     @BeforeEach
     public void setUp(Jedis jedis) {
-        jedis.flushDB();
         Map<String, Double> members = new HashMap<>();
         members.put("alpha", 0d);
         members.put("bar", 0d);

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZRemRangeByRank.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZRemRangeByRank.java
@@ -18,7 +18,6 @@ public class TestZRemRangeByRank {
 
     @BeforeEach
     public void clearKey(Jedis jedis) {
-        jedis.flushDB();
         Map<String, Double> members = new HashMap<>();
         members.put("a", 1d);
         members.put("b", 2d);

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZRemRangeByScore.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZRemRangeByScore.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.sortedsets;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -16,11 +15,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class TestZRemRangeByScore {
 
     private static final String ZSET_KEY = "myzset";
-
-    @BeforeEach
-    public void clearKey(Jedis jedis) {
-        jedis.flushDB();
-    }
 
     @TestTemplate
     public void whenUsingZremrangeByScore_EnsureItReturnsZeroForNonDefinedKey(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZRevRange.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZRevRange.java
@@ -19,7 +19,6 @@ public class TestZRevRange {
 
     @BeforeEach
     public void setUp(Jedis jedis) {
-        jedis.flushDB();
         jedis.zadd(ZSET_KEY, 2, "aaaa");
         jedis.zadd(ZSET_KEY, 3, "bbbb");
         jedis.zadd(ZSET_KEY, 1, "cccc");

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZRevRangeByScore.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZRevRangeByScore.java
@@ -16,7 +16,6 @@ public class TestZRevRangeByScore {
 
     @BeforeEach
     public void setUp(Jedis jedis) {
-        jedis.flushDB();
         jedis.zadd(ZSET_KEY, 1, "one");
         jedis.zadd(ZSET_KEY, 2, "two");
         jedis.zadd(ZSET_KEY, 3, "three");

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZRevRank.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZRevRank.java
@@ -15,7 +15,6 @@ public class TestZRevRank {
 
     @BeforeEach
     public void setUp(Jedis jedis) {
-        jedis.flushDB();
         jedis.zadd(ZSET_KEY, 2, "bbb");
         jedis.zadd(ZSET_KEY, 3, "ccc");
         jedis.zadd(ZSET_KEY, 1, "aaa");

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZScan.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZScan.java
@@ -21,7 +21,6 @@ public class TestZScan {
 
     @BeforeEach
     public void setUp(Jedis jedis) {
-        jedis.flushDB();
         for (int i = 0; i < 10; i++) {
             jedis.zadd(ZSET_KEY, i, "a" + i);
         }

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZScore.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZScore.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.sortedsets;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -12,11 +11,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestZScore {
 
     private static final String ZSET_KEY = "myzset";
-
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     @TestTemplate
     public void testZScoreNotExistKey(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZUnion.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZUnion.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.sortedsets;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -17,11 +16,6 @@ public class TestZUnion {
 
     private static final String ZSET_KEY_1 = "myzset";
     private static final String ZSET_KEY_2 = "ztmp";
-
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     @TestTemplate
     public void testZUnionNotExistKeyToNotExistDest(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZUnionStore.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZUnionStore.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.sortedsets;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -24,11 +23,6 @@ public class TestZUnionStore {
     private static final String ZSET_KEY_1 = "myzset";
     private static final String ZSET_KEY_2 = "ztmp";
     private static final String ZSET_KEY_OUT = "zout";
-
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     @TestTemplate
     public void testZUnionStoreNotExistKeyToNotExistDest(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZadd.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZadd.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.sortedsets;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -20,11 +19,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class TestZadd {
 
     private static final String ZSET_KEY = "myzset";
-
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     @TestTemplate
     public void zaddAddsKey(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZincrBy.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/sortedsets/TestZincrBy.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.sortedsets;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -14,11 +13,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @ExtendWith(ComparisonBase.class)
 public class TestZincrBy {
-
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     @TestTemplate
     public void testIncrByToExistsValue(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/streams/XAddTests.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/streams/XAddTests.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.streams;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -18,11 +17,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class XAddTests {
 
     private static final java.util.Map<String, String> HASH = Collections.singletonMap("a", "b");
-
-    @BeforeEach
-    void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     @TestTemplate
     void whenAllOptionsUsed_ensureWorksCorrect(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/streams/XDelTests.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/streams/XDelTests.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.streams;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -19,11 +18,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class XDelTests {
 
     private static final Map<String, String> HASH = Collections.singletonMap("a", "b");
-
-    @BeforeEach
-    void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     @TestTemplate
     void whenTopEntryIsDeleted_ensureTopIdDoesNotDecrease(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/streams/XLenTests.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/streams/XLenTests.java
@@ -17,8 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class XLenTests {
     Random r;
     @BeforeEach
-    void setUp(Jedis jedis) {
-        jedis.flushAll();
+    void setUp() {
         r = new Random();
     }
 

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/streams/XReadTests.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/streams/XReadTests.java
@@ -40,8 +40,7 @@ public class XReadTests {
     private Jedis blockedClient;
 
     @BeforeEach
-    public void setUp(Jedis jedis, HostAndPort hostAndPort) {
-        jedis.flushAll();
+    public void setUp(HostAndPort hostAndPort) {
         blockedClient = new Jedis(hostAndPort.getHost(), hostAndPort.getPort());
         scheduledThreadPool = Executors.newScheduledThreadPool(4);
     }

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/streams/XTrimTests.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/streams/XTrimTests.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.streams;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -18,12 +17,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ExtendWith(ComparisonBase.class)
 public class XTrimTests {
     private static final Map<String, String> HASH = Collections.singletonMap("a", "b");
-    
-    @BeforeEach
-    void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
-
 
     @TestTemplate
     void xtrimXdelAreReflectedByRecordedFirstEntry(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/strings/GetExTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/strings/GetExTest.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.strings;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.testcontainers.shaded.org.awaitility.Awaitility;
@@ -31,11 +30,6 @@ public class GetExTest {
     private static final String INVALID_EXPIRE = "ERR invalid expire time in 'getex' command";
     private static final String NOT_AN_INTEGER = "ERR value is not an integer or out of range";
     private static final String SYNTAX_ERROR = "ERR syntax error";
-
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     /** Sends GETEX verbatim, for the cases Jedis's typed API cannot express. */
     private static Object getex(Jedis jedis, String... args) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/strings/StringOperationsTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/strings/StringOperationsTest.java
@@ -2,7 +2,6 @@ package com.github.fppt.jedismock.comparisontests.strings;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
 import org.assertj.core.api.SoftAssertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.HostAndPort;
@@ -25,11 +24,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class StringOperationsTest {
 
     private final static byte[] msg = new byte[]{(byte) 0xbe};
-
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     @TestTemplate
     public void whenSettingKeyAndRetrievingIt_CorrectResultIsReturned(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/strings/TestAppend.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/strings/TestAppend.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.strings;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -10,10 +9,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(ComparisonBase.class)
 public class TestAppend {
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushDB();
-    }
 
     @TestTemplate
     public void testAppendEmpty(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/strings/TestGetDel.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/strings/TestGetDel.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.strings;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -15,11 +14,6 @@ public class TestGetDel {
 
     String key = "key";
     String value = "value";
-
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     @TestTemplate
     public void testGetAndDel(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/strings/TestGetRange.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/strings/TestGetRange.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.strings;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -34,11 +33,6 @@ public class TestGetRange {
     private static final Protocol.Command[] BOTH_NAMES = {
             Protocol.Command.GETRANGE, Protocol.Command.SUBSTR
     };
-
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     private static String range(Jedis jedis, Protocol.Command command, String key, String start, String end) {
         Object reply = jedis.sendCommand(command, key, start, end);

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/strings/TestMGet.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/strings/TestMGet.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.strings;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -10,10 +9,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(ComparisonBase.class)
 public class TestMGet {
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     @TestTemplate
     public void mget(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/strings/TestMSetNX.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/strings/TestMSetNX.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.strings;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -10,10 +9,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(ComparisonBase.class)
 public class TestMSetNX {
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     @TestTemplate
     public void msetnx(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/strings/TestSet.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/strings/TestSet.java
@@ -2,7 +2,6 @@ package com.github.fppt.jedismock.comparisontests.strings;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
 import org.assertj.core.api.SoftAssertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -20,11 +19,6 @@ public class TestSet {
     private static final String SET_KEY = "my_simple_key";
     private static final String SET_VALUE = "my_simple_value";
     private static final String SET_ANOTHER_VALUE = "another_value";
-
-    @BeforeEach
-    public void clearKey(Jedis jedis) {
-        jedis.flushDB();
-    }
 
     // SET key value NX
     @TestTemplate

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/strings/TestSetGet.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/strings/TestSetGet.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.strings;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -32,11 +31,6 @@ public class TestSetGet {
     private static final String SYNTAX_ERROR = "ERR syntax error";
     private static final String NOT_AN_INTEGER = "ERR value is not an integer or out of range";
     private static final String INVALID_EXPIRE = "ERR invalid expire time in 'set' command";
-
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushDB();
-    }
 
     private static Object set(Jedis jedis, String... args) {
         return jedis.sendCommand(Protocol.Command.SET, args);

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/strings/TestSetOptionParsing.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/strings/TestSetOptionParsing.java
@@ -2,7 +2,6 @@ package com.github.fppt.jedismock.comparisontests.strings;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
 import org.assertj.core.api.SoftAssertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -30,11 +29,6 @@ public class TestSetOptionParsing {
     private static final String SYNTAX_ERROR = "ERR syntax error";
     private static final String NOT_AN_INTEGER = "ERR value is not an integer or out of range";
     private static final String INVALID_EXPIRE = "ERR invalid expire time in 'set' command";
-
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushDB();
-    }
 
     private static Object set(Jedis jedis, String... args) {
         return jedis.sendCommand(Protocol.Command.SET, args);

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/strings/TestSetRange.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/strings/TestSetRange.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.strings;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -11,10 +10,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @ExtendWith(ComparisonBase.class)
 public class TestSetRange {
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     @TestTemplate
     public void setRange(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/transactions/TransactionOperationsTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/transactions/TransactionOperationsTest.java
@@ -1,7 +1,6 @@
 package com.github.fppt.jedismock.comparisontests.transactions;
 
 import com.github.fppt.jedismock.comparisontests.ComparisonBase;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
@@ -17,11 +16,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @ExtendWith(ComparisonBase.class)
 public class TransactionOperationsTest {
-
-    @BeforeEach
-    public void setUp(Jedis jedis) {
-        jedis.flushAll();
-    }
 
     @TestTemplate
     public void whenTransactionWithMultiplePushesIsExecuted_EnsureResultsAreSaved(Jedis jedis) {

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/transactions/WatchExpiredKeyComparisonTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/transactions/WatchExpiredKeyComparisonTest.java
@@ -27,7 +27,6 @@ public class WatchExpiredKeyComparisonTest {
 
     @TestTemplate
     public void watchConsidersTouchedExpiredKeys(Jedis jedis) {
-        jedis.flushAll();
         jedis.del("x");
         jedis.set("x", "foo");
         jedis.pexpire("x", 50);

--- a/src/test/java/com/github/fppt/jedismock/comparisontests/transactions/WatchInPlaceMutationTest.java
+++ b/src/test/java/com/github/fppt/jedismock/comparisontests/transactions/WatchInPlaceMutationTest.java
@@ -28,8 +28,7 @@ public class WatchInPlaceMutationTest {
     private Jedis anotherJedis;
 
     @BeforeEach
-    public void setup(Jedis jedis, HostAndPort hostAndPort) {
-        jedis.flushAll();
+    public void setup(HostAndPort hostAndPort) {
         anotherJedis = new Jedis(hostAndPort.getHost(), hostAndPort.getPort());
     }
 


### PR DESCRIPTION
removes the need to specify the same operation in a `@BeforeEach` method in every test class.